### PR TITLE
Add `/tmp/` at to the top of .gitignore if not found

### DIFF
--- a/lib/tasks/transform-files.js
+++ b/lib/tasks/transform-files.js
@@ -30,9 +30,16 @@ export default async function modifyFiles(showErrorTrace) {
     showErrorTrace,
   );
 
-  let code = await readFile('.gitignore', 'utf-8');
-  if (!code.match(/\/?tmp\/?[\n\r]/)) {
-    await writeFile('.gitignore', `/tmp/\n\n${code}`, 'utf-8');
+  try {
+    let code = await readFile('.gitignore', 'utf-8');
+    if (!code.match(/\/?tmp\/?[\n\r]/)) {
+      await writeFile('.gitignore', `/tmp/\n\n${code}`, 'utf-8');
+    }
+  } catch (e) {
+    console.log('Skiping file .gitignore since it was not found.');
+    if (showErrorTrace) {
+      console.log(e);
+    }
   }
 }
 

--- a/lib/tasks/transform-files.js
+++ b/lib/tasks/transform-files.js
@@ -29,6 +29,11 @@ export default async function modifyFiles(showErrorTrace) {
     transformTestHelper,
     showErrorTrace,
   );
+
+  let code = await readFile('.gitignore', 'utf-8');
+  if (!code.match(/\/?tmp\/?[\n\r]/)) {
+    await writeFile('.gitignore', `/tmp/\n\n${code}`, 'utf-8');
+  }
 }
 
 async function transformWithReplace(file, transformFunction, options) {


### PR DESCRIPTION
When building with Vite, `tmp/compat-prebuild/.stage2-output` is created in the app folder. We don't want to stage this. With this PR, the codemod adds `/tmp/` at the top of `.gitignore` if no pattern is found to ignore the tmp folder.