### PR TITLE
Iterate on ensure-v2-addon task

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,8 @@ The codemod will look at all your Ember dependencies and will advise you for upd
 
 When you use Embroider in an app that depends on v1 addons, Embroider will try to auto-fix the v1 addons in a way that makes them compatible with Vite. This approach works for a number of known addons, but we cannot guarantee it will work for any v1 addon you use. The best way to avoid issues is that your classic app already relies only on v2 addons, and the codemod will guide you in that direction:
 
-- If one of your addons is v1 but the latest version on npm is v2, it's recommended to update.
-- If one of your addons is v1 and no v2 format is available, it's recommended to look for a different alternative or make the addon v2.
-- If one of your v1 addons but is known as being correctly rewriten by Embroider, the codemod won't notice you about it.
+- If one of your addons is v1 but the latest version on npm is v2 or has become a basic package, it's recommended to update.
+- If one of your addons is v1, no v2 format is available, and we don't know for sure if Embroider can rewrite it, the codemod will display a warning so you pay attention to this addon's behavior when building with Vite.
 - If one of your v1 addons comes from Ember app blueprint and is no longer used in Embroider+Vite world, the codemod won't notify you about it (because it will be removed in a later step).
 
 ### Creating new required files

--- a/lib/tasks/ensure-v2-addons.js
+++ b/lib/tasks/ensure-v2-addons.js
@@ -33,16 +33,25 @@ export default async function ensureV2Addons() {
     }
 
     const { stdout } = await promiseExec(`npm view ${addon} ember-addon`);
-    if (stdout && stdout.includes('version: 2')) {
-      console.error(
-        `${addon} latest version is a v2 addon, we highly recommend that you update it before running this codemod again. Sometimes Embroider can auto-fix v1 addons, but it's usually better to upgrade.\n`,
-      );
-      shouldProcessExit = true;
+    if (stdout) {
+      // viewing ember-addon outputs something so it's still an ember-addon
+      if (stdout.includes('version: 2')) {
+        console.error(
+          `${addon} latest version is a v2 addon, we highly recommend that you update it before running this codemod again. Sometimes Embroider can auto-fix v1 addons, but it's usually better to upgrade.\n`,
+        );
+        shouldProcessExit = true;
+      } else {
+        console.warn(
+          `${addon} is a v1 addon that cannot be updated to v2 format. Sometimes Embroider can auto-fix v1 addons, but it's usually better to upgrade. Consider removing or replacing this dependency, or contributing to the addon to make it v2.\n`,
+        );
+        console.log('\n');
+        shouldProcessExit = true;
+      }
     } else {
-      console.warn(
-        `${addon} is a v1 addon that cannot be updated to v2 format. Sometimes Embroider can auto-fix v1 addons, but it's usually better to upgrade. Consider removing or replacing this dependency, or contributing to the addon to make it v2.\n`,
+      // viewing ember-addon doesn't output anything so it's now a basic npm package
+      console.error(
+        `${addon} latest version is no longer an ember-addon but a basic npm package, we highly recommend that you update it before running this codemod again. Sometimes Embroider can auto-fix v1 addons, but it's usually better to upgrade.\n`,
       );
-      console.log('\n');
       shouldProcessExit = true;
     }
   }

--- a/lib/tasks/ensure-v2-addons.js
+++ b/lib/tasks/ensure-v2-addons.js
@@ -42,10 +42,9 @@ export default async function ensureV2Addons() {
         shouldProcessExit = true;
       } else {
         console.warn(
-          `${addon} is a v1 addon that cannot be updated to v2 format. Sometimes Embroider can auto-fix v1 addons, but it's usually better to upgrade. Consider removing or replacing this dependency, or contributing to the addon to make it v2.\n`,
+          `${addon} is a v1 addon that cannot be updated to v2 format. Sometimes Embroider can auto-fix v1 addons, but the success is not guarantee for every addon. If you notice an issue, consider removing this dependency, or contributing to the addon to make it v2.\n`,
         );
         console.log('\n');
-        shouldProcessExit = true;
       }
     } else {
       // viewing ember-addon doesn't output anything so it's now a basic npm package


### PR DESCRIPTION
- If `npm view [pkg] ember-addon` doesn't output anything, safely assume the addon became a basic package and suggest to update.
- Simple warning instead of exit if the v1 addon cannot be updated.