### PR TITLE
Support Ember 5.12 (by updating packages)

### DIFF
--- a/lib/tasks/ensure-v2-addons.js
+++ b/lib/tasks/ensure-v2-addons.js
@@ -2,13 +2,12 @@ import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { exec } from 'node:child_process';
 import { promisify } from 'node:util';
-import { packagesToRemove } from './update-package-json.js';
+import { packagesToAdd, packagesToRemove } from './update-package-json.js';
 
 // These addons are v1, but we know for sure Embroider can deal with it,
 // because they are part of the "Vite app" blueprint.
 const v1CompatibleAddons = [
   '@ember/optional-features',
-  '@ember/string',
   '@glimmer/tracking',
   'ember-auto-import',
   'ember-cli-babel',
@@ -24,7 +23,8 @@ export default async function ensureV2Addons() {
   for (let addon of v1Addons) {
     if (
       packagesToRemove.includes(addon) ||
-      v1CompatibleAddons.includes(addon)
+      v1CompatibleAddons.includes(addon) ||
+      packagesToAdd.some(([p]) => p === addon)
     ) {
       // don't report:
       // - v1 addons the codemod will remove from package.json

--- a/lib/tasks/update-package-json.js
+++ b/lib/tasks/update-package-json.js
@@ -1,4 +1,5 @@
 import { readFile, writeFile } from 'node:fs/promises';
+import semver from 'semver';
 
 // These packages are used in the latest classic app blueprint,
 // but they are no longer used in the Vite app blueprint so the
@@ -15,15 +16,19 @@ export const packagesToRemove = [
   'webpack',
 ];
 
-const packagesToAdd = [
+export const packagesToAdd = [
   ['@babel/plugin-transform-runtime', '^7.26.9'],
   ['@ember/string', '^4.0.0'],
+  ['@ember/test-helpers', '^4.0.0'],
   ['@embroider/compat', '^4.0.0-alpha.0'],
   ['@embroider/config-meta-loader', '^1.0.0-alpha.0'],
   ['@embroider/core', '^4.0.0-alpha.0'],
   ['@embroider/vite', '^1.0.0-alpha.0'],
   ['@rollup/plugin-babel', '^6.0.4'],
   ['decorator-transforms', '^2.3.0'],
+  ['ember-load-initializers', '^3.0.0'],
+  ['ember-resolver', '^13.0.0'],
+  ['ember-qunit', '^9.0.0'],
   ['vite', '^6.0.0'],
 ];
 
@@ -71,23 +76,46 @@ function removePackages(packageJSON) {
   }
 }
 
+const states = {
+  updated: 1,
+  added: 2,
+};
+
 function addPackages(packageJSON) {
   console.log('Adding new required dependencies.');
-  let wasDepChange = false;
+  let hasNewDevDep = false;
   for (const [dep, version] of packagesToAdd) {
-    if (packageJSON['dependencies'] && packageJSON['dependencies'][dep]) {
-      wasDepChange = true;
-      packageJSON['dependencies'][dep] = version;
-    } else {
-      packageJSON['devDependencies'][dep] = version;
+    if (
+      updateVersion(packageJSON['dependencies'], dep, version) ===
+      states.updated
+    ) {
+      continue;
+    }
+    if (
+      updateVersion(packageJSON['devDependencies'], dep, version) ===
+      states.added
+    ) {
+      hasNewDevDep = true;
     }
   }
-  if (wasDepChange) {
-    packageJSON['dependencies'] = sortDependencies(packageJSON['dependencies']);
+  if (hasNewDevDep) {
+    packageJSON['devDependencies'] = sortDependencies(
+      packageJSON['devDependencies'],
+    );
   }
-  packageJSON['devDependencies'] = sortDependencies(
-    packageJSON['devDependencies'],
-  );
+}
+
+function updateVersion(deps, depToAdd, minimumVersion) {
+  if (!deps) return;
+  if (deps[depToAdd]) {
+    const version = deps[depToAdd];
+    if (semver.lt(semver.coerce(version), semver.coerce(minimumVersion))) {
+      deps[depToAdd] = minimumVersion;
+    }
+    return states.updated;
+  }
+  deps[depToAdd] = minimumVersion;
+  return states.added;
 }
 
 function sortDependencies(field) {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   },
   "dependencies": {
     "@embroider/app-blueprint": "^0.23.0",
-    "commander": "^13.1.0"
+    "commander": "^13.1.0",
+    "semver": "^7.7.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.20.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       commander:
         specifier: ^13.1.0
         version: 13.1.0
+      semver:
+        specifier: ^7.7.1
+        version: 7.7.1
     devDependencies:
       '@eslint/js':
         specifier: ^9.20.0


### PR DESCRIPTION
**Add more packages in the "packages to add" list**

The version now represents a minimum required version for the package. We complete the list with packages that should already be there in the classic app but potentially don't meet the version requirement.

**Make the "packages to add" smarter**

When updating packages, we compare the current version with the minimum required version, then we keep the higher.

This PR allows us to enable tests for Ember 5.12:
<img width="940" alt="Capture d’écran 2025-02-27 à 18 28 40" src="https://github.com/user-attachments/assets/fdf3e3bc-200b-4b68-a6e5-2e1c0d9500aa" />

Closes https://github.com/mainmatter/ember-vite-codemod/pull/20
