### PR TITLE
Remove devDep portfinder

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "fixturify": "^3.0.0",
     "globals": "^15.15.0",
     "package-up": "^5.0.0",
-    "portfinder": "^1.0.33",
     "prettier": "^3.5.1",
     "recast": "^0.23.9",
     "release-plan": "^0.13.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,9 +66,6 @@ importers:
       package-up:
         specifier: ^5.0.0
         version: 5.0.0
-      portfinder:
-        specifier: ^1.0.33
-        version: 1.0.33
       prettier:
         specifier: ^3.5.1
         version: 3.5.1

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -2,6 +2,6 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    testTimeout: 180_000,
+    testTimeout: 300_000,
   },
 });


### PR DESCRIPTION
This dependency was used when trying to implement test concurrency, but we didn't use it in the end.