### PR TITLE
When an app has done a goofy (mismatched the modulePrefix from package.json#name), capture that goofiness and _expose it_ in the vite config

### DIFF
--- a/lib/tasks/transform-files.js
+++ b/lib/tasks/transform-files.js
@@ -8,6 +8,8 @@ import transformTestem from '../transforms/testem.js';
 import transformTestHelper from '../transforms/test-helper.js';
 import transformApp from '../transforms/app.js';
 import { resolveWithExt } from '../utils/resolve-with-extension.js';
+import { getAppName } from '../utils/get-app-name.js';
+import * as viteConfig from '../transforms/vite-config.js';
 
 export default async function modifyFiles(options) {
   await transformWithReplace('index.html', transformIndexHTML, {
@@ -31,6 +33,9 @@ export default async function modifyFiles(options) {
     options,
   );
 
+  // Compatibility assurances
+  await handleModulePrefixMisMatch(options);
+
   try {
     let code = await readFile('.gitignore', 'utf-8');
     if (!code.match(/\/?tmp\/?[\n\r]/)) {
@@ -42,6 +47,22 @@ export default async function modifyFiles(options) {
       console.log(e);
     }
   }
+}
+
+async function handleModulePrefixMisMatch(options) {
+  if (options.isEmbroiderWebpack) return;
+
+  const packageJSON = JSON.parse(await readFile('package.json', 'utf-8'));
+  const modulePrefix = await getAppName();
+
+  if (packageJSON.name === modulePrefix) return;
+
+  await transformWithReplace(
+    resolveWithExt('vite.config'),
+    (code) =>
+      viteConfig.addModulePrefixAlias(code, modulePrefix, packageJSON.name),
+    options,
+  );
 }
 
 async function transformWithReplace(file, transformFunction, options) {

--- a/lib/tasks/transform-files.js
+++ b/lib/tasks/transform-files.js
@@ -7,6 +7,7 @@ import transformIndexHTML from '../transforms/index-html.js';
 import transformTestem from '../transforms/testem.js';
 import transformTestHelper from '../transforms/test-helper.js';
 import transformApp from '../transforms/app.js';
+import { resolveWithExt } from '../utils/resolve-with-extension.js';
 
 export default async function modifyFiles(options) {
   await transformWithReplace('index.html', transformIndexHTML, {
@@ -17,10 +18,18 @@ export default async function modifyFiles(options) {
   });
   await transformWithReplace('app/config/environment.js', transformEnvironment);
 
-  await transformWithAst('ember-cli-build.js', transformEmberCliBuild, options);
-  await transformWithAst('testem.js', transformTestem, options);
-  await transformWithAst('app/app.js', transformApp, options);
-  await transformWithAst('tests/test-helper.js', transformTestHelper, options);
+  await transformWithAst(
+    resolveWithExt('ember-cli-build'),
+    transformEmberCliBuild,
+    options,
+  );
+  await transformWithAst(resolveWithExt('testem'), transformTestem, options);
+  await transformWithAst(resolveWithExt('app/app'), transformApp, options);
+  await transformWithAst(
+    resolveWithExt('tests/test-helper'),
+    transformTestHelper,
+    options,
+  );
 
   try {
     let code = await readFile('.gitignore', 'utf-8');

--- a/lib/transforms/vite-config.js
+++ b/lib/transforms/vite-config.js
@@ -1,0 +1,24 @@
+const mismatchedModulePrefixReplacements = [
+  {
+    before: `export default defineConfig({`,
+    after: `export default defineConfig({
+  resolve: {
+    alias: {
+      '\${FAKE_NAME}': '\${REAL_NAME}',
+    }
+  },`,
+  },
+];
+
+export function addModulePrefixAlias(code, fakeName, realName) {
+  const replacements = [...mismatchedModulePrefixReplacements];
+
+  for (const replacement of replacements) {
+    let after = replacement.after
+      .replace('${REAL_NAME}', realName)
+      .replace('${FAKE_NAME}', fakeName);
+
+    code = code.replaceAll(replacement.before, after);
+  }
+  return code;
+}

--- a/lib/utils/resolve-with-extension.js
+++ b/lib/utils/resolve-with-extension.js
@@ -1,0 +1,18 @@
+import { existsSync } from 'node:fs';
+
+const extensions = ['.js', '.ts', '.cjs', '.mjs'];
+
+/**
+ * @param {string} filePath
+ */
+export function resolveWithExt(filePath) {
+  for (let ext of extensions) {
+    let candidate = filePath + ext;
+
+    if (existsSync(candidate)) return candidate;
+  }
+
+  throw new Error(
+    `Could not find ${filePath} with any of the extensions: ${extensions.join(', ')}`,
+  );
+}

--- a/tests/all-versions.test.js
+++ b/tests/all-versions.test.js
@@ -43,6 +43,21 @@ describe('Test on all Ember versions', function () {
   }
 });
 
+describe('Test on Ember versions with typescript', function () {
+  it.concurrent(
+    `should work for ember version ember-cli-latest with Embroider+Webpack`,
+    async function ({ expect }) {
+      await executeTest(
+        expect,
+        'ember-cli-latest',
+        undefined,
+        '--typescript --skip-npm --pnpm',
+        getPort(),
+      );
+    },
+  );
+});
+
 describe('Test on Ember versions with Embroider+Webpack', function () {
   it.concurrent(
     `should work for ember version ember-cli-latest with Embroider+Webpack`,


### PR DESCRIPTION
Builds on top of https://github.com/mainmatter/ember-vite-codemod/pull/37
(because I wanted the resolve utility from #37)

but this PR is really just the one commit: [1e7e50f](https://github.com/mainmatter/ember-vite-codemod/pull/38/commits/1e7e50fbdc9fe217958564d5b44d268c5512c471)

It doesn't look like there is an existing pattern for one-off scenarios -- do you have an opinions on how those should be added to the test suite?