### PR TITLE
split CI by ember version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,11 @@ jobs:
           - standard
           - typescript
           - webpack
+        version:
+          - ember-cli-5.4
+          - ember-cli-5.8
+          - ember-cli-5.12
+          - ember-cli-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -45,4 +50,4 @@ jobs:
           node-version: 18
           cache: pnpm
       - run: pnpm i --frozen-lockfile
-      - run: pnpm run test tests/${{ matrix.file }}.test.js
+      - run: pnpm vitest -t ${{matrix.version}} tests/${{ matrix.file }}.test.js


### PR DESCRIPTION
This will hopefully speed up CI but it should also give us a clearer signal when a particular version has issues 👍 