### PR TITLE
Remove `@embroider/webpack` + don't report `@embroider/macros` and `@embroider/util`

### DIFF
--- a/lib/tasks/ensure-v2-addons.js
+++ b/lib/tasks/ensure-v2-addons.js
@@ -3,9 +3,11 @@ import { execa } from 'execa';
 import { packagesToAdd, packagesToRemove } from './update-package-json.js';
 
 // These addons are v1, but we know for sure Embroider can deal with it,
-// because they are part of the "Vite app" blueprint.
+// because they are part of the "Vite app" blueprint or the Embroider ecosystem.
 const v1CompatibleAddons = [
   '@ember/optional-features',
+  '@embroider/macros',
+  '@embroider/util',
   '@glimmer/tracking',
   'ember-auto-import',
   'ember-cli-babel',

--- a/lib/tasks/update-package-json.js
+++ b/lib/tasks/update-package-json.js
@@ -5,6 +5,7 @@ import semver from 'semver';
 // but they are no longer used in the Vite app blueprint so the
 // codemod should remove them.
 export const packagesToRemove = [
+  '@embroider/webpack',
   'broccoli-asset-rev',
   'ember-cli-app-version',
   'ember-cli-clean-css',


### PR DESCRIPTION
Fixes #61,

This PR: 
- improves the reporting exceptions for v1 addons.
- cleans-up the migration from `@embroider/webpack` by removing the package.