### PR TITLE
Fix/ dependencies duplication

### DIFF
--- a/lib/tasks/update-package-json.js
+++ b/lib/tasks/update-package-json.js
@@ -37,6 +37,7 @@ export const packagesToAdd = [
 
 export default async function updatePackageJson() {
   const packageJSON = JSON.parse(await readFile('package.json', 'utf-8'));
+
   removePackages(packageJSON);
   addPackages(packageJSON);
 
@@ -51,10 +52,12 @@ export default async function updatePackageJson() {
   };
 
   // Update commands
-  (packageJSON.scripts.build = 'vite build'),
-    (packageJSON.scripts.start = 'vite'),
-    (packageJSON.scripts['test:ember'] =
-      'vite build --mode test && ember test --path dist');
+  packageJSON.scripts = {
+    ...packageJSON.scripts,
+    build: 'vite build',
+    start: 'vite',
+    'test:ember': 'vite build --mode test && ember test --path dist',
+  };
 
   await writeFile(
     'package.json',
@@ -65,11 +68,13 @@ export default async function updatePackageJson() {
 
 function removePackages(packageJSON) {
   console.log('Removing dependencies that are no longer used.');
-  packageJSON['devDependencies'] = Object.fromEntries(
-    Object.entries(packageJSON['devDependencies']).filter(
-      ([dep]) => !packagesToRemove.includes(dep),
-    ),
-  );
+  if (packageJSON['devDependencies']) {
+    packageJSON['devDependencies'] = Object.fromEntries(
+      Object.entries(packageJSON['devDependencies']).filter(
+        ([dep]) => !packagesToRemove.includes(dep),
+      ),
+    );
+  }
   if (packageJSON['dependencies']) {
     packageJSON['dependencies'] = Object.fromEntries(
       Object.entries(packageJSON['dependencies']).filter(
@@ -79,25 +84,16 @@ function removePackages(packageJSON) {
   }
 }
 
-const states = {
-  updated: 1,
-  added: 2,
-};
-
 function addPackages(packageJSON) {
   console.log('Adding new required dependencies.');
   let hasNewDevDep = false;
   for (const [dep, version] of packagesToAdd) {
-    if (
-      updateVersion(packageJSON['dependencies'], dep, version) ===
-      states.updated
-    ) {
-      continue;
-    }
-    if (
-      updateVersion(packageJSON['devDependencies'], dep, version) ===
-      states.added
-    ) {
+    let isUpdated =
+      updateVersion(packageJSON['dependencies'], dep, version) ||
+      updateVersion(packageJSON['devDependencies'], dep, version);
+    if (!isUpdated) {
+      packageJSON['devDependencies'] = packageJSON['devDependencies'] ?? {};
+      addNewDependency(packageJSON['devDependencies'], dep, version);
       hasNewDevDep = true;
     }
   }
@@ -109,16 +105,25 @@ function addPackages(packageJSON) {
 }
 
 function updateVersion(deps, depToAdd, minimumVersion) {
-  if (!deps) return;
+  if (!deps || !depToAdd) return;
   if (deps[depToAdd]) {
     const version = deps[depToAdd];
-    if (semver.lt(semver.coerce(version), semver.coerce(minimumVersion))) {
+    if (
+      semver.lt(
+        semver.coerce(version, { includePrerelease: true }),
+        semver.coerce(minimumVersion, { includePrerelease: true }),
+      )
+    ) {
       deps[depToAdd] = minimumVersion;
     }
-    return states.updated;
+    return true;
   }
+  return false;
+}
+
+function addNewDependency(deps, depToAdd, minimumVersion) {
+  if (!deps || !depToAdd) return;
   deps[depToAdd] = minimumVersion;
-  return states.added;
 }
 
 function sortDependencies(field) {

--- a/lib/tasks/update-package-json.test.js
+++ b/lib/tasks/update-package-json.test.js
@@ -1,0 +1,164 @@
+import { describe, it, beforeEach, expect, vi } from 'vitest';
+
+import updatePackageJson from './update-package-json';
+
+let files;
+
+vi.mock('node:fs/promises', () => {
+  return {
+    readFile: (filename) => {
+      return files[filename];
+    },
+    writeFile: (filename, content) => {
+      files[filename] = JSON.parse(content);
+    },
+  };
+});
+
+describe('updatePackageJson() function', () => {
+  beforeEach(() => {
+    files = {};
+  });
+
+  it('does not error with an empty package.json', async () => {
+    files = {
+      'package.json': '{}',
+    };
+    await updatePackageJson();
+  });
+
+  it('updates the scripts', async () => {
+    files = {
+      'package.json': JSON.stringify({
+        scripts: {
+          build: 'ember build --environment=production',
+          lint: 'concurrently "pnpm:lint:*(!fix)" --names "lint:" --prefixColors auto',
+          'lint:hbs': 'ember-template-lint .',
+          'lint:js': 'eslint . --cache',
+          start: 'ember serve',
+          test: 'concurrently "pnpm:lint" "pnpm:test:*" --names "lint,test:" --prefixColors auto',
+          'test:ember': 'ember test',
+        },
+      }),
+    };
+    await updatePackageJson();
+    expect(files['package.json'].scripts).toMatchInlineSnapshot(`
+      {
+        "build": "vite build",
+        "lint": "concurrently "pnpm:lint:*(!fix)" --names "lint:" --prefixColors auto",
+        "lint:hbs": "ember-template-lint .",
+        "lint:js": "eslint . --cache",
+        "start": "vite",
+        "test": "concurrently "pnpm:lint" "pnpm:test:*" --names "lint,test:" --prefixColors auto",
+        "test:ember": "vite build --mode test && ember test --path dist",
+      }
+    `);
+  });
+
+  it('adds the expected meta', async () => {
+    files = {
+      'package.json': '{}',
+    };
+    await updatePackageJson();
+    expect(files['package.json']['ember-addon']).toMatchInlineSnapshot(`
+      {
+        "type": "app",
+        "version": 2,
+      }
+    `);
+    expect(files['package.json']['exports']).toMatchInlineSnapshot(`
+      {
+        "./*": "./app/*",
+        "./tests/*": "./tests/*",
+      }
+    `);
+  });
+
+  it('adds missing dependencies in devDependencies', async () => {
+    files = {
+      'package.json': JSON.stringify({
+        devDependencies: {},
+      }),
+    };
+
+    await updatePackageJson();
+    expect(files['package.json']['devDependencies']).toMatchInlineSnapshot(`
+      {
+        "@babel/plugin-transform-runtime": "^7.26.9",
+        "@ember/string": "^4.0.0",
+        "@ember/test-helpers": "^4.0.0",
+        "@embroider/compat": "^4.0.0-alpha.13",
+        "@embroider/config-meta-loader": "^1.0.0-alpha.3",
+        "@embroider/core": "^4.0.0-alpha.9",
+        "@embroider/vite": "^1.0.0-alpha.11",
+        "@rollup/plugin-babel": "^6.0.4",
+        "babel-plugin-ember-template-compilation": "^2.3.0",
+        "decorator-transforms": "^2.3.0",
+        "ember-load-initializers": "^3.0.0",
+        "ember-qunit": "^9.0.0",
+        "ember-resolver": "^13.0.0",
+        "vite": "^6.0.0",
+      }
+    `);
+  });
+
+  it('removes dependencies', async () => {
+    files = {
+      'package.json': JSON.stringify({
+        dependencies: {
+          'loader.js': 'x.x.x',
+          webpack: 'x.x.x',
+        },
+        devDependencies: {
+          '@embroider/webpack': 'x.x.x',
+          'broccoli-asset-rev': 'x.x.x',
+        },
+      }),
+    };
+    await updatePackageJson();
+    const pck = files['package.json'];
+    expect(pck['dependencies']).toStrictEqual({});
+    expect(pck['devDependencies']).not.toHaveProperty('@embroider/webpack');
+    expect(pck['devDependencies']).not.toHaveProperty('broccoli-asset-rev');
+    expect(pck['devDependencies']).toHaveProperty('vite');
+  });
+
+  // Note: the snapshot approach also asserts the absence of duplicated deps between dependencies and devDependencies
+  it('updates dependencies to the minimum required version', async () => {
+    files = {
+      'package.json': JSON.stringify({
+        dependencies: {
+          '@ember/string': '^3.0.0',
+          vite: '100.0.0', // make sure the test always go through a case where the current version is bigger
+        },
+        devDependencies: {
+          '@embroider/compat': '^4.0.0-alpha.11',
+          '@embroider/core': '100.0.0', // make sure the test always go through a case where the current version is bigger
+        },
+      }),
+    };
+    await updatePackageJson();
+    expect(files['package.json']['dependencies']).toMatchInlineSnapshot(`
+      {
+        "@ember/string": "^4.0.0",
+        "vite": "100.0.0",
+      }
+    `);
+    expect(files['package.json']['devDependencies']).toMatchInlineSnapshot(`
+      {
+        "@babel/plugin-transform-runtime": "^7.26.9",
+        "@ember/test-helpers": "^4.0.0",
+        "@embroider/compat": "^4.0.0-alpha.13",
+        "@embroider/config-meta-loader": "^1.0.0-alpha.3",
+        "@embroider/core": "100.0.0",
+        "@embroider/vite": "^1.0.0-alpha.11",
+        "@rollup/plugin-babel": "^6.0.4",
+        "babel-plugin-ember-template-compilation": "^2.3.0",
+        "decorator-transforms": "^2.3.0",
+        "ember-load-initializers": "^3.0.0",
+        "ember-qunit": "^9.0.0",
+        "ember-resolver": "^13.0.0",
+      }
+    `);
+  });
+});


### PR DESCRIPTION
Fixes #44 

This PR simplifies and fixes the logic in `update-package-json.js`. This version: 
- is easier to read and therefore maintain, 
- configures `semver` functions correctly to compare prerealeases,
- manages the missing fields better.

Since the dependencies to add and update may still change at this stage, the unit test uses a snapshot approach to ease maintenance.
