### PR TITLE
Fix/ in ensure-v2-addons, look for local package.json first

### DIFF
--- a/lib/tasks/ensure-v2-addons.js
+++ b/lib/tasks/ensure-v2-addons.js
@@ -1,4 +1,5 @@
 import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
 import { execa } from 'execa';
 import { packagesToAdd, packagesToRemove } from './update-package-json.js';
 
@@ -15,7 +16,7 @@ const v1CompatibleAddons = [
   'ember-template-imports',
 ];
 
-export default async function ensureV2Addons(options) {
+export default async function ensureV2Addons(options = {}) {
   let shouldProcessExit = false;
   const v1Addons = await getV1Addons(options);
 
@@ -31,26 +32,35 @@ export default async function ensureV2Addons(options) {
       continue;
     }
 
-    const { stdout } = await execa`npm view ${addon} ember-addon`;
-    if (stdout) {
-      // viewing ember-addon outputs something so it's still an ember-addon
-      if (stdout.includes('version: 2')) {
+    try {
+      const { stdout } = await execa`npm view ${addon} ember-addon`;
+      if (stdout) {
+        // viewing ember-addon outputs something so it's still an ember-addon
+        if (stdout.includes('version: 2')) {
+          console.error(
+            `${addon} latest version is a v2 addon, we highly recommend that you update it before running this codemod again. Sometimes Embroider can auto-fix v1 addons, but it's usually better to upgrade.\n`,
+          );
+          shouldProcessExit = true;
+        } else {
+          console.warn(
+            `${addon} is a v1 addon that cannot be updated to v2 format. Sometimes Embroider can auto-fix v1 addons, but the success is not guarantee for every addon. If you notice an issue, consider removing this dependency, or contributing to the addon to make it v2.\n`,
+          );
+          console.log('\n');
+        }
+      } else {
+        // viewing ember-addon doesn't output anything so it's now a basic npm package
         console.error(
-          `${addon} latest version is a v2 addon, we highly recommend that you update it before running this codemod again. Sometimes Embroider can auto-fix v1 addons, but it's usually better to upgrade.\n`,
+          `${addon} latest version is no longer an ember-addon but a basic npm package, we highly recommend that you update it before running this codemod again. Sometimes Embroider can auto-fix v1 addons, but it's usually better to upgrade.\n`,
         );
         shouldProcessExit = true;
-      } else {
-        console.warn(
-          `${addon} is a v1 addon that cannot be updated to v2 format. Sometimes Embroider can auto-fix v1 addons, but the success is not guarantee for every addon. If you notice an issue, consider removing this dependency, or contributing to the addon to make it v2.\n`,
-        );
-        console.log('\n');
       }
-    } else {
-      // viewing ember-addon doesn't output anything so it's now a basic npm package
-      console.error(
-        `${addon} latest version is no longer an ember-addon but a basic npm package, we highly recommend that you update it before running this codemod again. Sometimes Embroider can auto-fix v1 addons, but it's usually better to upgrade.\n`,
+    } catch (e) {
+      console.warn(
+        `${addon} was identified as a v1 addon, but it was not possible to check if a v2 format was released. Is this package private? Sometimes Embroider can auto-fix v1 addons, but the success is not guarantee for every addon. If you notice an issue, consider removing this dependency, or making it v2.`,
       );
-      shouldProcessExit = true;
+      if (options.errorTrace) {
+        console.error(e.message ?? e);
+      }
     }
   }
 
@@ -67,30 +77,47 @@ async function getV1Addons({ errorTrace = false } = {}) {
   const deps = { ...packageJSON.devDependencies, ...packageJSON.dependencies };
   const v1packages = [];
   for (const [depName, version] of Object.entries(deps)) {
+    let pkg;
+    let pkgInfo;
     try {
-      const { stdout } =
-        await execa`npm view --json ${depName}@${version} ember-addon keywords`;
-      const pkg = JSON.parse(stdout);
-      if (
-        pkg.keywords?.includes('ember-addon') &&
-        pkg['ember-addon']?.version !== 2
-      ) {
-        v1packages.push(depName);
+      pkg = JSON.parse(
+        await readFile(join('node_modules', depName, 'package.json'), 'utf8'),
+      );
+      if (pkg) {
+        pkgInfo = pkg['ember-addon'];
       }
     } catch (e) {
-      if (e.message.includes('npm error code E404')) {
+      if (errorTrace) {
+        console.warn(
+          `The package ${depName} was found in the dependencies, but its package.json could not be read. Falling back to npm public information.`,
+        );
+        console.error(e.message ?? e);
+      }
+    }
+
+    if (!pkg) {
+      try {
+        const { stdout } =
+          await execa`npm view --json ${depName}@${version} ember-addon`;
+        if (stdout) {
+          pkgInfo = JSON.parse(stdout);
+          if (pkgInfo.length) {
+            // npm view will return all results matching the version based on semver (e.g ^6.0.0)
+            pkgInfo = pkgInfo[pkgInfo.length - 1];
+          }
+        }
+      } catch (e) {
         console.warn(
           `Could not look up information about ${depName}. You need to verify if this addon is a v2 addon manually.`,
         );
-      } else {
-        console.warn(
-          `Unexpected error received looking up information about ${depName}.`,
-        );
+        if (errorTrace) {
+          console.error(e.message ?? e);
+        }
       }
+    }
 
-      if (errorTrace) {
-        console.error(e.message);
-      }
+    if (pkgInfo && pkgInfo.version !== 2) {
+      v1packages.push(depName);
     }
   }
   return v1packages;

--- a/lib/tasks/ensure-v2-addons.test.js
+++ b/lib/tasks/ensure-v2-addons.test.js
@@ -33,6 +33,18 @@ describe('ensureV2Addons() function', () => {
     await ensureV2Addons();
   });
 
+  it('shows no error when you have a dependency that does not use ember-addon meta', async () => {
+    files = {
+      'package.json': JSON.stringify({
+        dependencies: {
+          '@babel/eslint-parser': '^7.26.10',
+        },
+      }),
+    };
+
+    await ensureV2Addons();
+  });
+
   it('shows no error when you have a dependency that was upgraded to v2', async () => {
     files = {
       'package.json': JSON.stringify({
@@ -73,6 +85,29 @@ describe('ensureV2Addons() function', () => {
     expect(consoleWarn).toBeCalledTimes(1);
     expect(consoleWarn).toBeCalledWith(
       'Could not look up information about @mainmatter/super-private-does-really-exist-i-promise. You need to verify if this addon is a v2 addon manually.',
+    );
+  });
+
+  it('looks into local package.json first', async () => {
+    files = {
+      'package.json': JSON.stringify({
+        devDependencies: {
+          '@mainmatter/super-private-does-really-exist-i-promise': '^5.0.0',
+        },
+      }),
+      'node_modules/@mainmatter/super-private-does-really-exist-i-promise/package.json':
+        JSON.stringify({
+          'ember-addon': {
+            configPath: 'tests/dummy/config',
+          },
+        }),
+    };
+
+    await ensureV2Addons();
+
+    expect(consoleWarn).toBeCalledTimes(1);
+    expect(consoleWarn).toBeCalledWith(
+      '@mainmatter/super-private-does-really-exist-i-promise was identified as a v1 addon, but it was not possible to check if a v2 format was released. Is this package private? Sometimes Embroider can auto-fix v1 addons, but the success is not guarantee for every addon. If you notice an issue, consider removing this dependency, or making it v2.',
     );
   });
 });


### PR DESCRIPTION
Fixes #42, #72

This PR is a partial revert of PR #39, to go back to a state we didn't have `ensure-v2-addons` triggering multiple error logs:
```
Unexpected error received looking up information about @babel/eslint-parser.
Unexpected error received looking up information about @babel/helper-replace-supers.
Unexpected error received looking up information about @ember/string.
```

We keep the idea from #39 to look at public information on npm, but we do this only if the package.json was not found locally to avoid sending too many requests to npm.

The use case that motivated PR #39 (codemod doesn't exit when looking up a private package) has been properly handled relying on the local package approach.