### PR TITLE
Required minimum version for optional packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -25,6 +24,19 @@ jobs:
           cache: pnpm
       - run: pnpm i --frozen-lockfile
       - run: pnpm run lint
+
+  test-lib:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: pnpm
+      - run: pnpm i --frozen-lockfile
+      - run: pnpm test:lib
 
   test:
     runs-on: ubuntu-latest

--- a/lib/tasks/ensure-v2-addons.test.js
+++ b/lib/tasks/ensure-v2-addons.test.js
@@ -23,6 +23,7 @@ const consoleWarn = vi
 describe('ensureV2Addons() function', () => {
   beforeEach(() => {
     files = {};
+    consoleWarn.mockClear();
   });
 
   it('wont error with an empty package.json', async () => {

--- a/lib/tasks/update-package-json.js
+++ b/lib/tasks/update-package-json.js
@@ -1,9 +1,11 @@
 import { readFile, writeFile } from 'node:fs/promises';
 import semver from 'semver';
 
-// These packages are used in the latest classic app blueprint,
-// but they are no longer used in the Vite app blueprint so the
-// codemod should remove them.
+/*
+ * These packages are used in the latest classic app blueprint,
+ * but they are no longer used in the Vite app blueprint so the
+ * codemod should remove them.
+ */
 export const packagesToRemove = [
   '@embroider/webpack',
   'broccoli-asset-rev',
@@ -18,6 +20,13 @@ export const packagesToRemove = [
   'webpack',
 ];
 
+/*
+ * These packages are new requirements for the Vite app.
+ * The version is the minimum required version. Depending
+ * on the context, the codemod can: install the package,
+ * change its version to the minimum required version, or
+ * keep it as it is.
+ */
 export const packagesToAdd = [
   ['@babel/plugin-transform-runtime', '^7.26.9'],
   ['@ember/string', '^4.0.0'],
@@ -35,11 +44,20 @@ export const packagesToAdd = [
   ['vite', '^6.0.0'],
 ];
 
+/*
+ * These packages are not requirements for the Vite app.
+ * However, if they are used, then they have a minimum
+ * required version, and the codemod will make sure it's
+ * installed.
+ */
+export const packagesToUpdate = [['@embroider/router', '^3.0.0-alpha.1']];
+
 export default async function updatePackageJson() {
   const packageJSON = JSON.parse(await readFile('package.json', 'utf-8'));
 
   removePackages(packageJSON);
   addPackages(packageJSON);
+  updatePackages(packageJSON);
 
   // Add app v2 meta
   packageJSON['ember-addon'] = {
@@ -101,6 +119,14 @@ function addPackages(packageJSON) {
     packageJSON['devDependencies'] = sortDependencies(
       packageJSON['devDependencies'],
     );
+  }
+}
+
+function updatePackages(packageJSON) {
+  console.log('Updating optional dependencies.');
+  for (const [dep, version] of packagesToUpdate) {
+    updateVersion(packageJSON['dependencies'], dep, version) ||
+      updateVersion(packageJSON['devDependencies'], dep, version);
   }
 }
 

--- a/lib/tasks/update-package-json.test.js
+++ b/lib/tasks/update-package-json.test.js
@@ -87,7 +87,7 @@ describe('updatePackageJson() function', () => {
         "@babel/plugin-transform-runtime": "^7.26.9",
         "@ember/string": "^4.0.0",
         "@ember/test-helpers": "^4.0.0",
-        "@embroider/compat": "^4.0.0-alpha.13",
+        "@embroider/compat": "^4.0.0-alpha.14",
         "@embroider/config-meta-loader": "^1.0.0-alpha.3",
         "@embroider/core": "^4.0.0-alpha.9",
         "@embroider/vite": "^1.0.0-alpha.11",
@@ -124,7 +124,7 @@ describe('updatePackageJson() function', () => {
   });
 
   // Note: the snapshot approach also asserts the absence of duplicated deps between dependencies and devDependencies
-  it('updates dependencies to the minimum required version', async () => {
+  it('updates dependencies to the minimum required version (packagesToAdd)', async () => {
     files = {
       'package.json': JSON.stringify({
         dependencies: {
@@ -148,7 +148,7 @@ describe('updatePackageJson() function', () => {
       {
         "@babel/plugin-transform-runtime": "^7.26.9",
         "@ember/test-helpers": "^4.0.0",
-        "@embroider/compat": "^4.0.0-alpha.13",
+        "@embroider/compat": "^4.0.0-alpha.14",
         "@embroider/config-meta-loader": "^1.0.0-alpha.3",
         "@embroider/core": "100.0.0",
         "@embroider/vite": "^1.0.0-alpha.11",
@@ -160,5 +160,35 @@ describe('updatePackageJson() function', () => {
         "ember-resolver": "^13.0.0",
       }
     `);
+  });
+
+  it('updates dependencies to the minimum required version (packagesToUpdate)', async () => {
+    files = {
+      'package.json': JSON.stringify({
+        devDependencies: {
+          '@embroider/router': '2.1.8',
+        },
+      }),
+    };
+    await updatePackageJson();
+    let pck = files['package.json'];
+    expect(pck['devDependencies']).toHaveProperty(
+      '@embroider/router',
+      '^3.0.0-alpha.1',
+    );
+
+    files = {
+      'package.json': JSON.stringify({
+        dependencies: {
+          '@embroider/router': '2.1.8',
+        },
+      }),
+    };
+    await updatePackageJson();
+    pck = files['package.json'];
+    expect(pck['dependencies']).toHaveProperty(
+      '@embroider/router',
+      '^3.0.0-alpha.1',
+    );
   });
 });

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "lint:format": "prettier . --cache --check",
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
-    "test": "vitest"
+    "test": "vitest",
+    "test:lib": "vitest lib/**/*.test.js"
   },
   "dependencies": {
     "@embroider/app-blueprint": "^0.23.0",


### PR DESCRIPTION
Fixes #43 

This PR adds a new functionality to `update-package-json` task. It introduces the concept of minimum version for optional packages. For instance, if and only if you have `@embroider/router` installed, then you should use at least `3.0.0-alpha.1`.

Additionally, this PR ensures that the CI runs the unit tests of the lib's functions, which wasn't the case before. Tests had to be run manually and regressions could be easily introduced.