### PR TITLE
Don't report `ember-source` is available as v2

### DIFF
--- a/lib/tasks/ensure-v2-addons.js
+++ b/lib/tasks/ensure-v2-addons.js
@@ -14,6 +14,10 @@ const v1CompatibleAddons = [
   'ember-cli-babel',
   'ember-cli-htmlbars',
   'ember-template-imports',
+  // ember-source latest is v2 but Vite support is available back to 3.28,
+  // so it's not a problem is the currently installed version is v1.
+  // The task ensure-ember-cli has a dedicated pre-check for the version.
+  'ember-source',
 ];
 
 export default async function ensureV2Addons(options = {}) {

--- a/lib/tasks/ensure-v2-addons.js
+++ b/lib/tasks/ensure-v2-addons.js
@@ -15,7 +15,7 @@ const v1CompatibleAddons = [
   'ember-cli-htmlbars',
   'ember-template-imports',
   // ember-source latest is v2 but Vite support is available back to 3.28,
-  // so it's not a problem is the currently installed version is v1.
+  // so it's not a problem if the currently installed version is v1.
   // The task ensure-ember-cli has a dedicated pre-check for the version.
   'ember-source',
 ];


### PR DESCRIPTION
Fixes #87 

Add `ember-source` to the list of v1 addons that we don't want to report to developers in `ensure-v2-addon` task.