### PR TITLE
Detect `@embroider/webpack` automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,12 @@ npx ember-vite-codemod@latest [options]
 
 ### options
 
-| Option              | Default | Description                                                                                                                                                                                                                                |
-| :------------------ | :-----: | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| --skip-git          |  false  | By default, the process exits if the git repository is not clean. Use this option to execute the command anyway at your own risk.                                                                                                          |
-| --skip-v2-addon     |  false  | By default, the process exits if it detects v1 addons you could update or remove before switching to Vite. Use this option to execute the rest of the codemod anyway and discover if Embroider can deal with your v1 addons without issue. |
-| --embroider-webpack |  false  | Use this option to indicate your app builds with @embroider/webpack. Essentially, the codemod will have different expectations about the content of ember-cli-build.                                                                       |
-| --ts                |  false  | Use this option to indicate your app uses typescript. It will impact what files the codemod creates and the packages it installs.                                                                                                          |
-| --error-trace       |  false  | In case of error, use this option to print the full error trace when it's available.                                                                                                                                                       |
+| Option          | Default | Description                                                                                                                                                                                                                                |
+| :-------------- | :-----: | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| --skip-git      |  false  | By default, the process exits if the git repository is not clean. Use this option to execute the command anyway at your own risk.                                                                                                          |
+| --skip-v2-addon |  false  | By default, the process exits if it detects v1 addons you could update or remove before switching to Vite. Use this option to execute the rest of the codemod anyway and discover if Embroider can deal with your v1 addons without issue. |
+| --ts            |  false  | Use this option to indicate your app uses typescript. It will impact what files the codemod creates and the packages it installs.                                                                                                          |
+| --error-trace   |  false  | In case of error, use this option to print the full error trace when it's available.                                                                                                                                                       |
 
 ## Steps
 

--- a/index.js
+++ b/index.js
@@ -39,6 +39,12 @@ program
 program.parse();
 const options = program.opts();
 
+if (options.embroiderWebpack) {
+  console.warn(
+    '--embroider-webpack option ignored. The codemod now adapts automatically if @embroider/webpack is found.\n',
+  );
+}
+
 // Tasks order is important
 if (!options.skipGit) {
   await checkGitStatus();
@@ -61,6 +67,12 @@ console.log('\nCreating new required files...\n');
 const projectType = options.ts ? 'ts' : 'js';
 await addMissingFiles({ projectType });
 await moveIndex();
+
+// Add an automatic option when @embroider/webpack is detected
+const packageJSON = JSON.parse(await readFile('package.json', 'utf-8'));
+options.embroiderWebpack =
+  packageJSON['dependencies']?.['@embroider/webpack'] ||
+  packageJSON['devDependencies']?.['@embroider/webpack'];
 
 console.log('\nRunning code replacements...\n');
 await transformFiles(options);

--- a/lib/transforms/ember-cli-build.test.js
+++ b/lib/transforms/ember-cli-build.test.js
@@ -1,0 +1,135 @@
+import { parse, print } from 'recast';
+import babelParser from 'recast/parsers/babel.js';
+import { describe, it, expect } from 'vitest';
+import transformEmberCliBuild from './ember-cli-build.js';
+
+describe('ember-cli-build() function', () => {
+  // Includes:
+  // - it adds @embroider/compat import
+  // - it adds @embroider/vite dynamic import
+  // - if uses compatBuild and buildOnce in the return statement
+  it('transforms a default ember-cli-build', async () => {
+    let ast = await parse(
+      `
+const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+module.exports = function (defaults) {
+  const app = new EmberApp(defaults, {});
+  return app.toTree();
+};`,
+      { parser: babelParser },
+    );
+
+    ast = await transformEmberCliBuild(ast, false);
+    const output = print(ast).code;
+
+    expect(output).toMatchInlineSnapshot(`
+      "
+      const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+
+      const {
+        compatBuild
+      } = require("@embroider/compat");
+
+      module.exports = async function(defaults) {
+        const {
+          buildOnce
+        } = await import("@embroider/vite");
+
+        const app = new EmberApp(defaults, {});
+        return compatBuild(app, buildOnce);
+      };"
+    `);
+  });
+
+  it('removes @embroider/webpack import at the top of the file (isEmbroiderWebpack)', async () => {
+    let ast = await parse(
+      `
+const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+const { Webpack } = require('@embroider/webpack');`,
+      { parser: babelParser },
+    );
+
+    ast = await transformEmberCliBuild(ast, true);
+    const output = print(ast).code;
+    expect(output).toMatchInlineSnapshot(`
+      "
+      const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+      const {
+        compatBuild
+      } = require("@embroider/compat");"
+    `);
+  });
+
+  it('removes @embroider/webpack import in the exported function (isEmbroiderWebpack)', async () => {
+    let ast = await parse(
+      `
+const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+module.exports = function (defaults) {
+  const { Webpack } = require('@embroider/webpack');
+  return require('@embroider/compat').compatBuild(app, Webpack, {});
+};`,
+      { parser: babelParser },
+    );
+
+    ast = await transformEmberCliBuild(ast, true);
+    const output = print(ast).code;
+    expect(output).toMatchInlineSnapshot(`
+      "
+      const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+
+      const {
+        compatBuild
+      } = require("@embroider/compat");
+
+      module.exports = async function(defaults) {
+        const {
+          buildOnce
+        } = await import("@embroider/vite");
+        return compatBuild(app, buildOnce, {});
+      };"
+    `);
+  });
+
+  it('preserves build options, except skipBabel (isEmbroiderWebpack)', async () => {
+    let ast = await parse(
+      `
+const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+module.exports = function (defaults) {
+  return require('@embroider/compat').compatBuild(app, Webpack, {
+    staticEmberSource: true,
+    staticAddonTrees: true,
+    staticAddonTestSupportTrees: true,
+    skipBabel: [
+      {
+        package: 'qunit',
+      },
+    ],
+  });
+};`,
+      { parser: babelParser },
+    );
+
+    ast = await transformEmberCliBuild(ast, true);
+    const output = print(ast).code;
+    expect(output).toMatchInlineSnapshot(`
+      "
+      const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+
+      const {
+        compatBuild
+      } = require("@embroider/compat");
+
+      module.exports = async function(defaults) {
+        const {
+          buildOnce
+        } = await import("@embroider/vite");
+
+        return compatBuild(app, buildOnce, {
+          staticEmberSource: true,
+          staticAddonTrees: true,
+          staticAddonTestSupportTrees: true
+        });
+      };"
+    `);
+  });
+});


### PR DESCRIPTION
Fixes #79 

This PR: 
- "Removes" `--embroider-webpack` option in favor of finding `@embroider/webpack` in the `package.json`.
- Creates the missing test for the transformation of `ember-cli-build`, which asserts  `@embroider/webpack` specific transformations are applied.

When the codemod implementation was started, introducing an option `--embroider-webpack` sounded like a good way to simplify the codemod operations by letting users specify the context. However, at the end of the day, there's only one transformation detail that depends on `@embroider/webpack` and the option can be easily forgotten. It seems better now to remove this option in favor of finding `@embroider/webpack` under the hood.
