### PR TITLE
Add `@babel/plugin-transform-typescript` if `--ts` is enabled

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ try {
   await run('Moving index.html', moveIndex);
 
   await run('Running code replacements...', transformFiles, options);
-  await run('Updating package.json', updatePackageJson);
+  await run('Updating package.json', updatePackageJson, options);
 
   console.log(
     '\nAll set! Re-install the app dependencies then run your linter',

--- a/lib/tasks/ensure-v2-addons.js
+++ b/lib/tasks/ensure-v2-addons.js
@@ -1,7 +1,11 @@
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { execa } from 'execa';
-import { packagesToAdd, packagesToRemove } from './update-package-json.js';
+import {
+  PACKAGES_TO_ADD,
+  PACKAGES_TO_ADD_TS,
+  PACKAGES_TO_REMOVE,
+} from './update-package-json.js';
 import { ExitError } from '../utils/exit.js';
 
 // These addons are v1, but we know for sure Embroider can deal with it,
@@ -21,13 +25,17 @@ const v1CompatibleAddons = [
   'ember-source',
 ];
 
-export default async function ensureV2Addons(options = {}) {
+export default async function ensureV2Addons(options = { ts: false }) {
   let shouldProcessExit = false;
   const v1Addons = await getV1Addons(options);
+  const packagesToAdd = [
+    ...PACKAGES_TO_ADD,
+    ...(options.ts ? PACKAGES_TO_ADD_TS : []),
+  ];
 
   for (let addon of v1Addons) {
     if (
-      packagesToRemove.includes(addon) ||
+      PACKAGES_TO_REMOVE.includes(addon) ||
       v1CompatibleAddons.includes(addon) ||
       packagesToAdd.some(([p]) => p === addon)
     ) {

--- a/lib/tasks/update-package-json.js
+++ b/lib/tasks/update-package-json.js
@@ -6,7 +6,7 @@ import semver from 'semver';
  * but they are no longer used in the Vite app blueprint so the
  * codemod should remove them.
  */
-export const packagesToRemove = [
+export const PACKAGES_TO_REMOVE = [
   '@embroider/webpack',
   'broccoli-asset-rev',
   'ember-cli-app-version',
@@ -27,7 +27,7 @@ export const packagesToRemove = [
  * change its version to the minimum required version, or
  * keep it as it is.
  */
-export const packagesToAdd = [
+export const PACKAGES_TO_ADD = [
   ['@babel/plugin-transform-runtime', '^7.26.9'],
   ['@ember/string', '^4.0.0'],
   ['@ember/test-helpers', '^4.0.0'],
@@ -44,20 +44,24 @@ export const packagesToAdd = [
   ['vite', '^6.0.0'],
 ];
 
+export const PACKAGES_TO_ADD_TS = [
+  ['@babel/plugin-transform-typescript', '^7.28.0'],
+];
+
 /*
  * These packages are not requirements for the Vite app.
  * However, if they are used, then they have a minimum
  * required version, and the codemod will make sure it's
  * installed.
  */
-export const packagesToUpdate = [['@embroider/router', '^3.0.1']];
+export const PACKAGES_TO_UPDATE = [['@embroider/router', '^3.0.1']];
 
-export default async function updatePackageJson() {
+export default async function updatePackageJson(options = { ts: false }) {
   const packageJSON = JSON.parse(await readFile('package.json', 'utf-8'));
 
-  removePackages(packageJSON);
-  addPackages(packageJSON);
-  updatePackages(packageJSON);
+  removePackages(packageJSON, options);
+  addPackages(packageJSON, options);
+  updatePackages(packageJSON, options);
 
   // Add app v2 meta
   packageJSON['ember-addon'] = {
@@ -89,22 +93,28 @@ function removePackages(packageJSON) {
   if (packageJSON['devDependencies']) {
     packageJSON['devDependencies'] = Object.fromEntries(
       Object.entries(packageJSON['devDependencies']).filter(
-        ([dep]) => !packagesToRemove.includes(dep),
+        ([dep]) => !PACKAGES_TO_REMOVE.includes(dep),
       ),
     );
   }
   if (packageJSON['dependencies']) {
     packageJSON['dependencies'] = Object.fromEntries(
       Object.entries(packageJSON['dependencies']).filter(
-        ([dep]) => !packagesToRemove.includes(dep),
+        ([dep]) => !PACKAGES_TO_REMOVE.includes(dep),
       ),
     );
   }
 }
 
-function addPackages(packageJSON) {
+function addPackages(packageJSON, options = { ts: false }) {
   console.log('Adding new required dependencies.');
+
+  const packagesToAdd = [
+    ...PACKAGES_TO_ADD,
+    ...(options.ts ? PACKAGES_TO_ADD_TS : []),
+  ];
   let hasNewDevDep = false;
+
   for (const [dep, version] of packagesToAdd) {
     let isUpdated =
       updateVersion(packageJSON['dependencies'], dep, version) ||
@@ -124,7 +134,7 @@ function addPackages(packageJSON) {
 
 function updatePackages(packageJSON) {
   console.log('Updating optional dependencies.');
-  for (const [dep, version] of packagesToUpdate) {
+  for (const [dep, version] of PACKAGES_TO_UPDATE) {
     updateVersion(packageJSON['dependencies'], dep, version) ||
       updateVersion(packageJSON['devDependencies'], dep, version);
   }

--- a/lib/tasks/update-package-json.test.js
+++ b/lib/tasks/update-package-json.test.js
@@ -102,6 +102,35 @@ describe('updatePackageJson() function', () => {
     `);
   });
 
+  it('adds missing dependencies in devDependencies for --ts', async () => {
+    files = {
+      'package.json': JSON.stringify({
+        devDependencies: {},
+      }),
+    };
+
+    await updatePackageJson({ ts: true });
+    expect(files['package.json']['devDependencies']).toMatchInlineSnapshot(`
+      {
+        "@babel/plugin-transform-runtime": "^7.26.9",
+        "@babel/plugin-transform-typescript": "^7.28.0",
+        "@ember/string": "^4.0.0",
+        "@ember/test-helpers": "^4.0.0",
+        "@embroider/compat": "^4.0.3",
+        "@embroider/config-meta-loader": "^1.0.0",
+        "@embroider/core": "^4.0.3",
+        "@embroider/vite": "^1.1.1",
+        "@rollup/plugin-babel": "^6.0.4",
+        "babel-plugin-ember-template-compilation": "^2.3.0",
+        "decorator-transforms": "^2.3.0",
+        "ember-load-initializers": "^3.0.0",
+        "ember-qunit": "^9.0.0",
+        "ember-resolver": "^13.0.0",
+        "vite": "^6.0.0",
+      }
+    `);
+  });
+
   it('removes dependencies', async () => {
     files = {
       'package.json': JSON.stringify({


### PR DESCRIPTION
- Refactor variable names to express that they are somewhat constant
- New `PACKAGES_TO_ADD_TS` constant for TypeScript-specific dependencies
- Thread `options` parameter through package management functions
- Add test coverage for TypeScript scenario
