### PR TITLE
Remove workaround for missing @glimmer/component import

### DIFF
--- a/tests/fixtures/tests/acceptance/index-test.js
+++ b/tests/fixtures/tests/acceptance/index-test.js
@@ -2,9 +2,6 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from '../helpers';
 
-// FIXME: Remove once https://github.com/embroider-build/ember-auto-import/pull/667 is merged
-import '@glimmer/component';
-
 module('Acceptance | index', function (hooks) {
   setupApplicationTest(hooks);
 


### PR DESCRIPTION
Needs https://github.com/embroider-build/ember-auto-import/pull/667