### PR TITLE
Print all no unsupported deps

### DIFF
--- a/lib/tasks/ensure-no-unsupported-deps.js
+++ b/lib/tasks/ensure-no-unsupported-deps.js
@@ -14,35 +14,40 @@ function checkDependency(packageJSON, dep, message) {
 export default async function ensureNoUnsupportedDeps() {
   const packageJSON = JSON.parse(await readFile('package.json', 'utf-8'));
 
-  const shouldExit =
-    checkDependency(
-      packageJSON,
-      'ember-fetch',
-      `Your app contains a dependency to ember-fetch. ember-fetch behaves a way that is incompatible with modern JavaScript tooling, including building with Vite.
+  let shouldExit = checkDependency(
+    packageJSON,
+    'ember-fetch',
+    `Your app contains a dependency to ember-fetch. ember-fetch behaves a way that is incompatible with modern JavaScript tooling, including building with Vite.
 Please remove ember-fetch dependency then run this codemod again. Check out https://rfcs.emberjs.com/id/1065-remove-ember-fetch to see recommended alternatives.
-    `,
-    ) ||
+  `,
+  );
+
+  shouldExit =
     checkDependency(
       packageJSON,
       'ember-composable-helpers',
       `Your app contains a dependency to ember-composable-helpers. ember-composable-helpers contains a "won't fix" Babel issue that makes it incompatible with Vite.
 Please move from the original ember-composable-helpers to @nullvoxpopuli/ember-composable-helpers then run this codemod again. Checkout the first section of the repository's README: https://github.com/NullVoxPopuli/ember-composable-helpers
-    `,
-    ) ||
+  `,
+    ) || shouldExit;
+
+  shouldExit =
     checkDependency(
       packageJSON,
       'ember-cli-mirage',
       `Your app contains a dependency to ember-cli-mirage. ember-cli-mirage doesn't work correctly with Vite.
 Please move from ember-cli-mirage to ember-mirage then run this codemod again. Checkout https://github.com/bgantzler/ember-mirage/blob/main/docs/migration.md for guidance.
-    `,
-    ) ||
+  `,
+    ) || shouldExit;
+
+  shouldExit =
     checkDependency(
       packageJSON,
       'ember-css-modules',
       `Your app contains a dependency to ember-css-modules. ember-css-modules behavior is incompatible with Vite, you should migrate to a different solution to manage your CSS modules.
 There is a recommended migration path that you can follow for a file by file migration to ember-scoped-css, which is compatible with Vite. Checkout https://github.com/BlueCutOfficial/css-modules-to-scoped-css
-    `,
-    );
+  `,
+    ) || shouldExit;
 
   if (shouldExit) {
     throw new ExitError('Detected unsupported dependencies');

--- a/lib/tasks/ensure-no-unsupported-deps.test.js
+++ b/lib/tasks/ensure-no-unsupported-deps.test.js
@@ -13,9 +13,7 @@ vi.mock('node:fs/promises', () => {
   };
 });
 
-const consoleLog = vi
-  .spyOn(console, 'log')
-  .mockImplementation(() => undefined);
+const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => undefined);
 
 describe('ensureNoUnsupportedDeps() function', () => {
   beforeEach(() => {
@@ -26,10 +24,10 @@ describe('ensureNoUnsupportedDeps() function', () => {
     files = {
       'package.json': JSON.stringify({
         dependencies: {
-          'supportedDep': '3.0.0',
+          supportedDep: '3.0.0',
         },
         devDependencies: {
-          'supportedDevDep': '3.0.0',
+          supportedDevDep: '3.0.0',
         },
       }),
     };
@@ -44,7 +42,9 @@ describe('ensureNoUnsupportedDeps() function', () => {
         },
       }),
     };
-    await expect(() => ensureNoUnsupportedDeps()).rejects.toThrowError(ExitError);
+    await expect(() => ensureNoUnsupportedDeps()).rejects.toThrowError(
+      ExitError,
+    );
   });
 
   it('detects unsupported dev dependency', async () => {
@@ -55,7 +55,9 @@ describe('ensureNoUnsupportedDeps() function', () => {
         },
       }),
     };
-    await expect(() => ensureNoUnsupportedDeps()).rejects.toThrowError(ExitError);
+    await expect(() => ensureNoUnsupportedDeps()).rejects.toThrowError(
+      ExitError,
+    );
   });
 
   it('logs several messages at once', async () => {
@@ -67,7 +69,19 @@ describe('ensureNoUnsupportedDeps() function', () => {
         },
       }),
     };
-    await expect(() => ensureNoUnsupportedDeps()).rejects.toThrowError(ExitError);
-    //expect(consoleLog).toBeCalledTimes(2);
+    await expect(() => ensureNoUnsupportedDeps()).rejects.toThrowError(
+      ExitError,
+    );
+    expect(consoleLog).toHaveBeenCalledTimes(2);
+    expect(consoleLog).toHaveBeenCalledWith(
+      `Your app contains a dependency to ember-cli-mirage. ember-cli-mirage doesn't work correctly with Vite.
+Please move from ember-cli-mirage to ember-mirage then run this codemod again. Checkout https://github.com/bgantzler/ember-mirage/blob/main/docs/migration.md for guidance.
+  `,
+    );
+    expect(consoleLog).toHaveBeenCalledWith(
+      `Your app contains a dependency to ember-css-modules. ember-css-modules behavior is incompatible with Vite, you should migrate to a different solution to manage your CSS modules.
+There is a recommended migration path that you can follow for a file by file migration to ember-scoped-css, which is compatible with Vite. Checkout https://github.com/BlueCutOfficial/css-modules-to-scoped-css
+  `,
+    );
   });
 });


### PR DESCRIPTION
Relates to #108, 
Relates to #99,

This PR changes slightly the conditional behavior in `ensureNoUnsupportedDeps` so the function continues to check the dependencies after an unsupported one is detected. This way, all the logs for all the unsupported deps are printed before the error is thrown.

Additionally, the missing unit test for this file has been added.