### PR TITLE
Resolve actual dependency versions

### DIFF
--- a/lib/tasks/ensure-ember-cli.js
+++ b/lib/tasks/ensure-ember-cli.js
@@ -1,13 +1,10 @@
-import { readFile } from 'node:fs/promises';
 import semver from 'semver';
 import { ExitError } from '../utils/exit.js';
+import { resolveVersion } from '../utils/resolve-version.js';
 
 export default async function ensureEmberCli() {
-  const packageJSON = JSON.parse(await readFile('package.json', 'utf-8'));
+  const emberSource = resolveVersion('ember-source');
 
-  const emberSource =
-    packageJSON['devDependencies']?.['ember-source'] ||
-    packageJSON['dependencies']?.['ember-source'];
   if (
     semver.lt(
       semver.coerce(emberSource, { includePrerelease: true }),
@@ -19,9 +16,8 @@ export default async function ensureEmberCli() {
     );
   }
 
-  const emberCli =
-    packageJSON['devDependencies']?.['ember-cli'] ||
-    packageJSON['dependencies']?.['ember-cli'];
+  const emberCli = resolveVersion('ember-cli');
+
   if (
     semver.lt(
       semver.coerce(emberCli, { includePrerelease: true }),

--- a/lib/tasks/ensure-ember-cli.test.js
+++ b/lib/tasks/ensure-ember-cli.test.js
@@ -14,9 +14,20 @@ vi.mock('node:fs/promises', () => {
 
 vi.spyOn(process, 'exit');
 
+let mockedVersions = {};
+
+vi.mock('../utils/resolve-version.js', () => {
+  return {
+    resolveVersion: function (packageName) {
+      return mockedVersions[packageName];
+    },
+  };
+});
+
 describe('ensureEmberCli() function', () => {
   beforeEach(() => {
     files = {};
+    mockedVersions = {};
   });
 
   it('throws if ember-source < 3.28', async () => {
@@ -28,8 +39,13 @@ describe('ensureEmberCli() function', () => {
         },
       }),
     };
+    mockedVersions = {
+      'ember-source': '3.8.0',
+      'ember-cli': '3.8.0',
+    };
+
     await expect(() => ensureEmberCli()).rejects.toThrowError(
-      'ember-source ~3.8.0 (< 3.28) was detected. Vite support is available from Ember 3.28 onwards.',
+      'ember-source 3.8.0 (< 3.28) was detected. Vite support is available from Ember 3.28 onwards.',
     );
   });
 
@@ -42,8 +58,12 @@ describe('ensureEmberCli() function', () => {
         },
       }),
     };
+    mockedVersions = {
+      'ember-source': '3.28.0',
+      'ember-cli': '3.28.0',
+    };
     await expect(() => ensureEmberCli()).rejects.toThrowError(
-      'ember-cli ~3.28.0 (< 4.12) was detected. Vite support requires at least ember-cli 4.12. You can update ember-cli independently of ember-source, Vite support is available from ember-source 3.28 onwards.',
+      'ember-cli 3.28.0 (< 4.12) was detected. Vite support requires at least ember-cli 4.12. You can update ember-cli independently of ember-source, Vite support is available from ember-source 3.28 onwards.',
     );
   });
 
@@ -55,6 +75,10 @@ describe('ensureEmberCli() function', () => {
           'ember-cli': '~4.12.0',
         },
       }),
+    };
+    mockedVersions = {
+      'ember-source': '3.28.0',
+      'ember-cli': '4.12.0',
     };
     await ensureEmberCli();
   });

--- a/lib/tasks/update-package-json.js
+++ b/lib/tasks/update-package-json.js
@@ -1,5 +1,6 @@
 import { readFile, writeFile } from 'node:fs/promises';
 import semver from 'semver';
+import { resolveVersion } from '../utils/resolve-version.js';
 
 /*
  * These packages are used in the latest classic app blueprint,
@@ -143,7 +144,7 @@ function updatePackages(packageJSON) {
 function updateVersion(deps, depToAdd, minimumVersion) {
   if (!deps || !depToAdd) return;
   if (deps[depToAdd]) {
-    const version = deps[depToAdd];
+    const version = resolveVersion(depToAdd);
     if (
       semver.lt(
         semver.coerce(version, { includePrerelease: true }),

--- a/lib/tasks/update-package-json.test.js
+++ b/lib/tasks/update-package-json.test.js
@@ -15,6 +15,27 @@ vi.mock('node:fs/promises', () => {
   };
 });
 
+vi.mock('../utils/resolve-version.js', () => {
+  return {
+    resolveVersion: function (packageName) {
+      switch (packageName) {
+        case '@ember/string':
+          return '3.0.0';
+        case 'vite':
+          return '100.0.0';
+        case '@embroider/compat':
+          return '4.0.0';
+        case '@embroider/core':
+          return '100.0.0';
+        case '@embroider/router':
+          return '2.1.8';
+        default:
+          return undefined;
+      }
+    },
+  };
+});
+
 describe('updatePackageJson() function', () => {
   beforeEach(() => {
     files = {};

--- a/lib/utils/resolve-version.js
+++ b/lib/utils/resolve-version.js
@@ -1,0 +1,14 @@
+import shared from '@embroider/shared-internals';
+const packageCache = new shared.PackageCache(process.cwd());
+const app = packageCache.get(packageCache.appRoot);
+
+export function resolveVersion(packageName) {
+  try {
+    return packageCache.resolve(packageName, app).version;
+  } catch (err) {
+    if (err.code === 'MODULE_NOT_FOUND') {
+      return undefined;
+    }
+    throw err;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@ember/app-blueprint": "^6.7.2",
+    "@embroider/shared-internals": "^3.0.1",
     "babel-remove-types": "^1.0.1",
     "commander": "^13.1.0",
     "execa": "^9.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@ember/app-blueprint':
         specifier: ^6.7.2
         version: 6.7.2
+      '@embroider/shared-internals':
+        specifier: ^3.0.1
+        version: 3.0.1
       babel-remove-types:
         specifier: ^1.0.1
         version: 1.0.1
@@ -243,6 +246,10 @@ packages:
 
   '@ember/app-blueprint@6.7.2':
     resolution: {integrity: sha512-p4HXE17YfJt5QIXTtlYdNozm6Cf2wUA9P24xD5E1Y4vgoCs7X5+XHyV58cNDJYM+qFcJ4jy8Dh0UrI1mF2M+0w==}
+
+  '@embroider/shared-internals@3.0.1':
+    resolution: {integrity: sha512-d7RQwDwqqHo7YvjE9t1rtIrCCYtbSoO0uRq2ikVhRh4hGS5OojZNu2ZtS0Wqrg+V72CRtMFr/hibTvHNsRM2Lg==}
+    engines: {node: 12.* || 14.* || >= 16}
 
   '@esbuild/aix-ppc64@0.25.0':
     resolution: {integrity: sha512-O7vun9Sf8DFjH2UtqK8Ku3LkquL9SZL8OLY1T5NZkA34+wG3OQF7cl4Ql8vdNzM6fzBbYfLaiRLIOZ+2FOCgBQ==}
@@ -1038,6 +1045,10 @@ packages:
     engines: {node: '>= 4.5.0'}
     hasBin: true
 
+  babel-import-util@3.0.1:
+    resolution: {integrity: sha512-2copPaWQFUrzooJVIVZA/Oppx/S/KOoZ4Uhr+XWEQDMZ8Rvq/0SNQpbdIyMBJ8IELWt10dewuJw+tX4XjOo7Rg==}
+    engines: {node: '>= 12.*'}
+
   babel-plugin-module-resolver@4.1.0:
     resolution: {integrity: sha512-MlX10UDheRr3lb3P0WcaIdtCSRlxdQsB1sBqL7W0raF070bGl1HQQq5K3T2vf2XAYie+ww+5AKC/WrkjRO2knA==}
     engines: {node: '>= 8.0.0'}
@@ -1068,6 +1079,10 @@ packages:
 
   before-after-hook@3.0.2:
     resolution: {integrity: sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==}
+
+  better-path-resolve@1.0.0:
+    resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
+    engines: {node: '>=4'}
 
   binaryextensions@2.3.0:
     resolution: {integrity: sha512-nAihlQsYGyc5Bwq6+EsubvANYGExeJKHDO3RjnvwU042fawQTQfM3Kxn7IHUXQOz4bzfwsGYYHGSvXyW4zOGLg==}
@@ -1908,6 +1923,9 @@ packages:
     resolution: {integrity: sha512-adcz01uGDrqBPniZrrYx6+tHe58ikc6j+cbX4+3aTG2OVJvQSL+LeisI6ixxtEZeklHRFB6FE6U1etTS6nRVfQ==}
     engines: {node: '>= 18'}
     hasBin: true
+
+  ember-rfc176-data@0.3.18:
+    resolution: {integrity: sha512-JtuLoYGSjay1W3MQAxt3eINWXNYYQliK90tLwtb8aeCuQK8zKGCRbBodVIrkcTqshULMnRuTOS6t1P7oQk3g6Q==}
 
   ember-source-channel-url@3.0.0:
     resolution: {integrity: sha512-vF/8BraOc66ZxIDo3VuNP7iiDrnXEINclJgSJmqwAAEpg84Zb1DHPI22XTXSDA+E8fW5btPUxu65c3ZXi8AQFA==}
@@ -2810,6 +2828,10 @@ packages:
     resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
     engines: {node: '>=18'}
 
+  is-subdir@1.2.0:
+    resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
+    engines: {node: '>=4'}
+
   is-type@0.0.1:
     resolution: {integrity: sha512-YwJh/zBVrcJ90aAnPBM0CbHvm7lG9ao7lIFeqTZ1UQj4iFLpM5CikdaU+dGGesrMJwxLqPGmjjrUrQ6Kn3Zh+w==}
 
@@ -2877,6 +2899,10 @@ packages:
 
   jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
+
+  js-string-escape@1.0.1:
+    resolution: {integrity: sha512-Smw4xcfIQ5LVjAOuJCvN/zIodzA/BBSsluuoSykP+lUvScIi4U6RJLfwHet5cxFnCswUjISV8oAXaqaJDY3chg==}
+    engines: {node: '>= 0.8'}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -3685,6 +3711,9 @@ packages:
     resolution: {integrity: sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==}
     engines: {node: '>=0.10.0'}
 
+  pkg-entry-points@1.1.1:
+    resolution: {integrity: sha512-BhZa7iaPmB4b3vKIACoppyUoYn8/sFs17VJJtzrzPZvEnN2nqrgg911tdL65lA2m1ml6UI3iPeYbZQ4VXpn1mA==}
+
   pkg-up@3.1.0:
     resolution: {integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==}
     engines: {node: '>=8'}
@@ -3899,6 +3928,10 @@ packages:
   resolve-url@0.2.1:
     resolution: {integrity: sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==}
     deprecated: https://github.com/lydell/resolve-url#deprecated
+
+  resolve.exports@2.0.3:
+    resolution: {integrity: sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==}
+    engines: {node: '>=10'}
 
   resolve@1.22.10:
     resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
@@ -4451,6 +4484,9 @@ packages:
 
   typedarray-to-buffer@3.1.5:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
+
+  typescript-memoize@1.1.1:
+    resolution: {integrity: sha512-GQ90TcKpIH4XxYTI2F98yEQYZgjNMOGPpOgdjIBhaLaWji5HPWlRnZ4AeA1hfBxtY7bCGDJsqDDHk/KaHOl5bA==}
 
   uc.micro@1.0.6:
     resolution: {integrity: sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==}
@@ -5007,6 +5043,24 @@ snapshots:
       ember-cli-string-utils: 1.1.0
       lodash: 4.17.21
       walk-sync: 3.0.0
+
+  '@embroider/shared-internals@3.0.1':
+    dependencies:
+      babel-import-util: 3.0.1
+      debug: 4.4.0
+      ember-rfc176-data: 0.3.18
+      fs-extra: 9.1.0
+      is-subdir: 1.2.0
+      js-string-escape: 1.0.1
+      lodash: 4.17.21
+      minimatch: 3.1.2
+      pkg-entry-points: 1.1.1
+      resolve-package-path: 4.0.3
+      resolve.exports: 2.0.3
+      semver: 7.7.1
+      typescript-memoize: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@esbuild/aix-ppc64@0.25.0':
     optional: true
@@ -5711,6 +5765,8 @@ snapshots:
 
   atob@2.1.2: {}
 
+  babel-import-util@3.0.1: {}
+
   babel-plugin-module-resolver@4.1.0:
     dependencies:
       find-babel-config: 1.2.2
@@ -5753,6 +5809,10 @@ snapshots:
       safe-buffer: 5.1.2
 
   before-after-hook@3.0.2: {}
+
+  better-path-resolve@1.0.0:
+    dependencies:
+      is-windows: 1.0.2
 
   binaryextensions@2.3.0: {}
 
@@ -7924,6 +7984,8 @@ snapshots:
       - walrus
       - whiskers
 
+  ember-rfc176-data@0.3.18: {}
+
   ember-source-channel-url@3.0.0(encoding@0.1.13):
     dependencies:
       node-fetch: 2.7.0(encoding@0.1.13)
@@ -9048,6 +9110,10 @@ snapshots:
 
   is-stream@4.0.1: {}
 
+  is-subdir@1.2.0:
+    dependencies:
+      better-path-resolve: 1.0.0
+
   is-type@0.0.1:
     dependencies:
       core-util-is: 1.0.3
@@ -9101,6 +9167,8 @@ snapshots:
       '@isaacs/cliui': 8.0.2
 
   jju@1.4.0: {}
+
+  js-string-escape@1.0.1: {}
 
   js-tokens@4.0.0: {}
 
@@ -9938,6 +10006,8 @@ snapshots:
 
   pinkie@2.0.4: {}
 
+  pkg-entry-points@1.1.1: {}
+
   pkg-up@3.1.0:
     dependencies:
       find-up: 3.0.0
@@ -10160,6 +10230,8 @@ snapshots:
       path-is-absolute: 1.0.1
 
   resolve-url@0.2.1: {}
+
+  resolve.exports@2.0.3: {}
 
   resolve@1.22.10:
     dependencies:
@@ -10868,6 +10940,8 @@ snapshots:
   typedarray-to-buffer@3.1.5:
     dependencies:
       is-typedarray: 1.0.0
+
+  typescript-memoize@1.1.1: {}
 
   uc.micro@1.0.6: {}
 


### PR DESCRIPTION
Fixes #113

The goal here is to do actual package resolution to see exactly what versions are in use. That is different from which version ranges are requested in the package.json. 

In order to do the resolution, I used the common PackageCache infrastructure from `@embroider/shared-internals`. It both enforces that we're resolving real declared dependencies and implements package resolution in a way that doesn't depend on the target package exposing its `package.json` in `exports`.