### PR TITLE
Add `ember-cli-deprecation-workflow` to the list of v1 compatible addons

### DIFF
--- a/lib/tasks/ensure-v2-addons.js
+++ b/lib/tasks/ensure-v2-addons.js
@@ -17,6 +17,7 @@ const v1CompatibleAddons = [
   '@glimmer/tracking',
   'ember-auto-import',
   'ember-cli-babel',
+  'ember-cli-deprecation-workflow',
   'ember-cli-htmlbars',
   'ember-template-imports',
   // ember-source latest is v2 but Vite support is available back to 3.28,


### PR DESCRIPTION
`ember-cli-deprecation-workflow` is a v1 addon, and there's no v2 format available yet. However, this addon is known as compatible since it's used in the Ember Vite app blueprint.

This PR adds `ember-cli-deprecation-workflow` to the explicit list of addons that don't report a warning when using the codemod on an app that depends on it.

That issue was mentioned in #114.
