### PR TITLE
Reduce the size of the output for ensure-v2-addons

### DIFF
--- a/lib/tasks/ensure-v2-addons.js
+++ b/lib/tasks/ensure-v2-addons.js
@@ -7,6 +7,7 @@ import {
   PACKAGES_TO_REMOVE,
 } from './update-package-json.js';
 import { ExitError } from '../utils/exit.js';
+import { bold, cyan } from 'yoctocolors';
 
 // These addons are v1, but we know for sure Embroider can deal with it,
 // because they are part of the "Vite app" blueprint or the Embroider ecosystem.
@@ -33,6 +34,13 @@ export default async function ensureV2Addons(options = { ts: false }) {
     ...(options.ts ? PACKAGES_TO_ADD_TS : []),
   ];
 
+  const logs = {
+    hasV2: [],
+    doesNotHaveV2: [],
+    hasBasicPackage: [],
+    isPrivate: [],
+  };
+
   for (let addon of v1Addons) {
     if (
       PACKAGES_TO_REMOVE.includes(addon) ||
@@ -50,35 +58,28 @@ export default async function ensureV2Addons(options = { ts: false }) {
       if (stdout) {
         // viewing ember-addon outputs something so it's still an ember-addon
         if (stdout.includes('version: 2')) {
-          console.error(
-            `"${addon}" latest version is a v2 addon, we highly recommend that you update it before running this codemod again. Sometimes Embroider can auto-fix v1 addons, but it's usually better to upgrade.`,
-          );
+          logs.hasV2.push(addon);
           shouldProcessExit = true;
         } else {
-          console.warn(
-            `"${addon}" is a v1 addon that cannot be updated to v2 format. Sometimes Embroider can auto-fix v1 addons, but the success is not guarantee for every addon. If you notice an issue, consider removing this dependency, or contributing to the addon to make it v2.`,
-          );
+          logs.doesNotHaveV2.push(addon);
         }
       } else {
         // viewing ember-addon doesn't output anything so it's now a basic npm package
-        console.error(
-          `"${addon}" latest version is no longer an ember-addon but a basic npm package, we highly recommend that you update it before running this codemod again. Sometimes Embroider can auto-fix v1 addons, but it's usually better to upgrade.`,
-        );
+        logs.hasBasicPackage.push(addon);
         shouldProcessExit = true;
       }
     } catch (e) {
-      console.warn(
-        `"${addon}" was identified as a v1 addon, but it was not possible to check if a v2 format was released. Is this package private? Sometimes Embroider can auto-fix v1 addons, but the success is not guarantee for every addon. If you notice an issue, consider removing this dependency, or making it v2.`,
-      );
+      logs.isPrivate.push(addon);
       if (options.errorTrace) {
         console.error(e.message ?? e);
       }
     }
   }
 
+  printSummary(logs);
   if (shouldProcessExit) {
     throw new ExitError(
-      'If you want to skip ahead and try without upgrading the addons above, pass the option --skip-v2-addon when running this codemod.',
+      `If you prefer to move to Vite now, and upgrade the addons above at a later time, pass the option ${bold('--skip-v2-addon')} when running this codemod.`,
     );
   }
 }
@@ -132,4 +133,45 @@ async function getV1Addons({ errorTrace = false } = {}) {
     }
   }
   return v1packages;
+}
+
+function printSummary(logs) {
+  const { hasBasicPackage, hasV2, doesNotHaveV2, isPrivate } = logs;
+  let summary = bold(`📝 Your Ember V1 addons summary\n`);
+
+  if (
+    !hasBasicPackage.length &&
+    !hasV2.length &&
+    !doesNotHaveV2.length &&
+    !isPrivate.length
+  ) {
+    summary += 'Nothing to report.';
+    console.log(summary);
+    return;
+  }
+  summary += `Embroider generally auto-fixes v1 addons so they keep working with Vite. However:
+* v2 addons are more performant, so we highly recommend to update everything that can be updated now.
+* it might happen for some v1 addons that the auto-fix does not work; if you notice an issue when running your Vite app, you can refer to the list below to potentially spot an incompatible addon.\n\n`;
+
+  if (hasBasicPackage.length) {
+    summary += `${cyan(bold(hasBasicPackage.length))} addon(s) whose latest version is now a ${cyan(bold('basic npm package'))} (it's no longer an ember-addon). Update whenever you can:\n`;
+    summary += hasBasicPackage.map((name) => `    * ${name}`).join('\n');
+    summary += '\n\n';
+  }
+  if (hasV2.length) {
+    summary += `${cyan(bold(hasV2.length))} addon(s) whose latest version is now a ${cyan(bold('v2 addon'))}. Update whenever you can:\n`;
+    summary += hasV2.map((name) => `    * ${name}`).join('\n');
+    summary += '\n\n';
+  }
+  if (doesNotHaveV2.length) {
+    summary += `${cyan(bold(doesNotHaveV2.length))} addon(s) which are ${cyan(bold('v1 only'))} and cannot be updated to v2 format. If you notice an issue, consider replacing this dependency, or contributing to the addon to make it v2:\n`;
+    summary += doesNotHaveV2.map((name) => `    * ${name}`).join('\n');
+    summary += '\n\n';
+  }
+  if (isPrivate.length) {
+    summary += `${cyan(bold(isPrivate.length))} addon(s) identified as a v1 addon, but it was ${cyan(bold('not possible to check'))} if a v2 format was released. Is this package private?\n`;
+    summary += isPrivate.map((name) => `    * ${name}`).join('\n');
+    summary += '\n\n';
+  }
+  console.log(summary);
 }

--- a/lib/tasks/ensure-v2-addons.test.js
+++ b/lib/tasks/ensure-v2-addons.test.js
@@ -13,6 +13,8 @@ vi.mock('node:fs/promises', () => {
   };
 });
 
+const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
 const consoleWarn = vi
   .spyOn(console, 'warn')
   .mockImplementation(() => undefined);
@@ -20,6 +22,7 @@ const consoleWarn = vi
 describe('ensureV2Addons() function', () => {
   beforeEach(() => {
     files = {};
+    consoleLog.mockClear();
     consoleWarn.mockClear();
   });
 
@@ -55,7 +58,7 @@ describe('ensureV2Addons() function', () => {
     await ensureV2Addons();
   });
 
-  it('shows an error when you have a dependency that was not yet upgraded to v2', async () => {
+  it('notifies and stops when you have a dependency that was not yet upgraded to v2', async () => {
     files = {
       'package.json': JSON.stringify({
         devDependencies: {
@@ -65,9 +68,40 @@ describe('ensureV2Addons() function', () => {
     };
 
     await expect(() => ensureV2Addons()).rejects.toThrowError(ExitError);
+    expect(consoleLog).toBeCalledTimes(1);
+    expect(consoleLog).toBeCalledWith(
+      expect.stringMatching(
+        /addon\(s\) whose latest version is now a .*v2 addon.*\..*ember-welcome-page/s,
+      ),
+    );
   });
 
-  it('warns but does not error when you have a package that can not be looked up publically', async () => {
+  it('notifies and continues when you have a dependency that is still a v1 addon', async () => {
+    /*
+     * ember-test-selectors is a relatively safe case to use because it will remain a v1 addon.
+     * The way to move to "v2" is to configure strip-test-selectors plugins in the Babel config
+     * directly. This test may have to change if we want to figure out a way to notify users
+     * about this, but that could be an overkill.
+     */
+    files = {
+      'package.json': JSON.stringify({
+        devDependencies: {
+          'ember-test-selectors': '^7.1.0',
+        },
+      }),
+    };
+
+    await ensureV2Addons();
+
+    expect(consoleLog).toBeCalledTimes(1);
+    expect(consoleLog).toBeCalledWith(
+      expect.stringMatching(
+        /addon\(s\) which are .*v1 only.*and cannot be updated to v2 format\..*ember-test-selectors/s,
+      ),
+    );
+  });
+
+  it('notifies and continues when you have a package that can not be looked up publically', async () => {
     files = {
       'package.json': JSON.stringify({
         devDependencies: {
@@ -101,9 +135,11 @@ describe('ensureV2Addons() function', () => {
 
     await ensureV2Addons();
 
-    expect(consoleWarn).toBeCalledTimes(1);
-    expect(consoleWarn).toBeCalledWith(
-      '"@mainmatter/super-private-does-really-exist-i-promise" was identified as a v1 addon, but it was not possible to check if a v2 format was released. Is this package private? Sometimes Embroider can auto-fix v1 addons, but the success is not guarantee for every addon. If you notice an issue, consider removing this dependency, or making it v2.',
+    expect(consoleLog).toBeCalledTimes(1);
+    expect(consoleLog).toBeCalledWith(
+      expect.stringMatching(
+        /Is this package private\?.*@mainmatter\/super-private-does-really-exist-i-promise/s,
+      ),
     );
   });
 });

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "lodash-es": "^4.17.21",
     "recast": "^0.23.9",
     "semver": "^7.7.1",
-    "yocto-spinner": "^1.0.0"
+    "yocto-spinner": "^1.0.0",
+    "yoctocolors": "^2.1.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.20.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       yocto-spinner:
         specifier: ^1.0.0
         version: 1.0.0
+      yoctocolors:
+        specifier: ^2.1.2
+        version: 2.1.2
     devDependencies:
       '@eslint/js':
         specifier: ^9.20.0
@@ -4839,8 +4842,8 @@ packages:
     resolution: {integrity: sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==}
     engines: {node: '>=18'}
 
-  yoctocolors@2.1.1:
-    resolution: {integrity: sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==}
+  yoctocolors@2.1.2:
+    resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
 
 snapshots:
@@ -8224,7 +8227,7 @@ snapshots:
       pretty-ms: 9.2.0
       signal-exit: 4.1.0
       strip-final-newline: 4.0.0
-      yoctocolors: 2.1.1
+      yoctocolors: 2.1.2
 
   exit@0.1.2: {}
 
@@ -11275,8 +11278,8 @@ snapshots:
 
   yocto-spinner@1.0.0:
     dependencies:
-      yoctocolors: 2.1.1
+      yoctocolors: 2.1.2
 
   yoctocolors-cjs@2.1.2: {}
 
-  yoctocolors@2.1.1: {}
+  yoctocolors@2.1.2: {}


### PR DESCRIPTION
Relates to #114.

## Context 

We have started thinking about how to improve the codemod output when checking the state of v1 addons in the application and suggesting upgrades. There are several aspects to consider: 1. Highlighting the fact that these upgrades are recommended but optional, 2. Making the upgrade step easier to skip, 3. Improving the readability of the audit results, and 4. Stating our philosophy regarding the "pedagogical _versus_ practical" purpose of this codemod.

This PR focuses on point 3: Improving the readability of the audit results.

## This PR

This PR removes the logs that occur during `ensure-v2-addons`. Instead, it builds one final log out of the information collected during the execution.

It takes the shape of a more readable summary, which: 
- introduces the purpose of the check to explain the intention behind it.
- groups the different cases to make them nicer to read.
- attempts to highlight the optional aspect of the upgrade by using a neutral color instead of warning and error colors...
- ...but still the execution is stopped if upgrade opportunities are found, so users can choose to manage that first. (Replacing the exit with something more user-friendly, like a y/n question, would be managed in a later PR.)

<img width="1069" height="356" alt="Capture d’écran 2025-11-28 à 18 12 55" src="https://github.com/user-attachments/assets/60e684fe-0e58-43c1-aa37-b19eb6ba9587" />

