### PR TITLE
stop adding the ember-addon metadata to package

### DIFF
--- a/lib/tasks/update-package-json.js
+++ b/lib/tasks/update-package-json.js
@@ -64,11 +64,6 @@ export default async function updatePackageJson(options = { ts: false }) {
   addPackages(packageJSON, options);
   updatePackages(packageJSON, options);
 
-  // Add app v2 meta
-  packageJSON['ember-addon'] = {
-    type: 'app',
-    version: 2,
-  };
   packageJSON.exports = {
     './tests/*': './tests/*',
     './*': './app/*',

--- a/lib/tasks/update-package-json.test.js
+++ b/lib/tasks/update-package-json.test.js
@@ -81,12 +81,6 @@ describe('updatePackageJson() function', () => {
       'package.json': '{}',
     };
     await updatePackageJson();
-    expect(files['package.json']['ember-addon']).toMatchInlineSnapshot(`
-      {
-        "type": "app",
-        "version": 2,
-      }
-    `);
     expect(files['package.json']['exports']).toMatchInlineSnapshot(`
       {
         "./*": "./app/*",


### PR DESCRIPTION
This is something that we needed early in the vite journey, it's not needed any more 👍 

Fixes https://github.com/mainmatter/ember-vite-codemod/issues/130