### PR TITLE
fix TypeScript parsing of files using recast

### DIFF
--- a/lib/tasks/transform-files.js
+++ b/lib/tasks/transform-files.js
@@ -1,5 +1,5 @@
 import { parse, print } from 'recast';
-import babelParser from 'recast/parsers/babel.js';
+import babelParser from '@babel/parser';
 import { readFile, writeFile } from 'node:fs/promises';
 import transformEmberCliBuild from '../transforms/ember-cli-build.js';
 import transformEnvironment from '../transforms/environment.js';
@@ -108,7 +108,20 @@ async function transformWithAst(
 
 async function getAst(file) {
   const code = await readFile(file, 'utf-8');
-  return parse(code, { parser: babelParser });
+  return parseAst(code);
+}
+
+export function parseAst(code) {
+  return parse(code, {
+    parser: {
+      parse(source) {
+        return babelParser.parse(source, {
+          sourceType: 'module',
+          plugins: ['typescript'],
+        });
+      },
+    },
+  });
 }
 
 async function setCode(file, ast) {

--- a/lib/tasks/transform-files.js
+++ b/lib/tasks/transform-files.js
@@ -117,7 +117,7 @@ export function parseAst(code) {
       parse(source) {
         return babelParser.parse(source, {
           sourceType: 'module',
-          plugins: ['typescript'],
+          plugins: ['typescript', 'classProperties'],
         });
       },
     },

--- a/lib/transforms/test-helper.js
+++ b/lib/transforms/test-helper.js
@@ -2,6 +2,8 @@ import { types, visit } from 'recast';
 
 const b = types.builders;
 
+const topLevelModuleTypes = ['ImportDeclaration', 'TSModuleDeclaration'];
+
 export default async function transformTestHelper(ast) {
   let exportStart = ast.program.body.find((node) => {
     return (
@@ -18,16 +20,22 @@ export default async function transformTestHelper(ast) {
     return ast;
   }
 
-  const allImports = ast.program.body.filter(
-    (node) => node.type === 'ImportDeclaration',
+  const allModuleLevelStatements = ast.program.body.filter((node) =>
+    topLevelModuleTypes.includes(node.type),
   );
-  const imports = allImports.filter(
-    (node) => node.source.value !== 'ember-qunit/test-loader',
+  const filteredModuleLevelStatements = allModuleLevelStatements.filter(
+    (node) => {
+      if (node.type !== 'ImportDeclaration') {
+        return true;
+      }
+      return node.source.value !== 'ember-qunit/test-loader';
+    },
   );
 
   // Local ember-qunit.start is qunitStart to prevent conflict with the start function we define
-  const emberQunitImport = imports.find(
-    (node) => node.source.value === 'ember-qunit',
+  const emberQunitImport = filteredModuleLevelStatements.find(
+    (node) =>
+      node.type === 'ImportDeclaration' && node.source.value === 'ember-qunit',
   );
   if (emberQunitImport) {
     const startSpecifierIndex = emberQunitImport.specifiers.findIndex(
@@ -51,11 +59,15 @@ export default async function transformTestHelper(ast) {
     );
     return ast;
   }
-  const emberExamImport = imports.find(
-    (node) => node.source.value === 'ember-exam/test-support',
+  const emberExamImport = filteredModuleLevelStatements.find(
+    (node) =>
+      node.type === 'ImportDeclaration' &&
+      node.source.value === 'ember-exam/test-support',
   );
-  const emberExamStartImport = imports.find(
-    (node) => node.source.value === 'ember-exam/test-support/start',
+  const emberExamStartImport = filteredModuleLevelStatements.find(
+    (node) =>
+      node.type === 'ImportDeclaration' &&
+      node.source.value === 'ember-exam/test-support/start',
   );
   const examImport = emberExamImport || emberExamStartImport;
   if (examImport) {
@@ -80,8 +92,9 @@ export default async function transformTestHelper(ast) {
 
   // Move all import declarations at the top
   ast.program.body.sort((a, b) => {
-    const isImportA = a.type === 'ImportDeclaration';
-    const isImportB = b.type === 'ImportDeclaration';
+    const isImportA = topLevelModuleTypes.includes(a.type);
+    const isImportB = topLevelModuleTypes.includes(b.type);
+
     if (isImportA && !isImportB) {
       return -1;
     } else if (!isImportA && isImportB) {
@@ -144,7 +157,7 @@ export default async function transformTestHelper(ast) {
   });
 
   // Wrap everything that is not an import in the start function
-  const nodesToWrap = ast.program.body.slice(allImports.length);
+  const nodesToWrap = ast.program.body.slice(allModuleLevelStatements.length);
 
   // Add `setupEmberOnerrorValidation` import and call if either is not present.
   const setupEmberOnerrorValidationImport = emberQunitImport.specifiers.find(
@@ -183,7 +196,7 @@ export default async function transformTestHelper(ast) {
   if (hasEmberExam) {
     exportStart.declaration.async = true;
   }
-  ast.program.body = [...imports, exportStart];
+  ast.program.body = [...filteredModuleLevelStatements, exportStart];
 
   return ast;
 }

--- a/lib/transforms/test-helper.test.js
+++ b/lib/transforms/test-helper.test.js
@@ -1,10 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import babelParser from 'recast/parsers/babel.js';
-import { parse, print } from 'recast';
+import { print } from 'recast';
 import transformTestHelper from './test-helper.js';
+import { parseAst } from '../tasks/transform-files.js';
 
 async function parseAndApply(input) {
-  let ast = await parse(input, { parser: babelParser });
+  let ast = parseAst(input);
   ast = await transformTestHelper(ast);
   return print(ast).code;
 }
@@ -39,6 +39,49 @@ describe('test-helper() function', () => {
 
               export function start() {
                       setApplication(Application.create(config.APP));
+
+                      setup(QUnit.assert);
+                      setupEmberOnerrorValidation();
+                      qunitStart();
+              }
+          "
+    `);
+  });
+
+  it('correctly moves all imports to the top before wrapping the body', async () => {
+    expect(
+      await parseAndApply(`
+        import Application from 'my-empty-classic-app/app';
+        import config from 'my-empty-classic-app/config/environment';
+        import * as QUnit from 'qunit';
+        import { setApplication } from '@ember/test-helpers';
+        import { setup } from 'qunit-dom';
+        import { loadTests } from 'ember-qunit/test-loader';
+
+        setApplication(Application.create(config.APP));
+        
+        import { start, setupEmberOnerrorValidation } from 'ember-qunit';
+        
+        
+        setup(QUnit.assert);
+        setupEmberOnerrorValidation();
+        loadTests();
+        start();
+    `),
+    ).toMatchInlineSnapshot(`
+      "
+              import Application from 'my-empty-classic-app/app';
+              import config from 'my-empty-classic-app/config/environment';
+              import * as QUnit from 'qunit';
+              import { setApplication } from '@ember/test-helpers';
+              import { setup } from 'qunit-dom';
+
+              import { start as qunitStart, setupEmberOnerrorValidation } from 'ember-qunit';
+
+
+              export function start() {
+                      setApplication(Application.create(config.APP));
+
 
                       setup(QUnit.assert);
                       setupEmberOnerrorValidation();
@@ -154,6 +197,48 @@ describe('test-helper() function', () => {
                       setup(QUnit.assert);
                       setupEmberOnerrorValidation();
                       await startEmberExam();
+              }
+          "
+    `);
+  });
+
+  it('works with TS syntax in the file', async () => {
+    expect(
+      await parseAndApply(`
+        import Application from 'my-empty-classic-app/app';
+        import config from 'my-empty-classic-app/config/environment';
+        import * as QUnit from 'qunit';
+        import { setApplication } from '@ember/test-helpers';
+        import { setup } from 'qunit-dom';
+        import { loadTests } from 'ember-qunit/test-loader';
+        import { start, setupEmberOnerrorValidation } from 'ember-qunit';
+
+        declare global {}
+        
+        setApplication(Application.create(config.APP));
+        
+        setup(QUnit.assert);
+        setupEmberOnerrorValidation();
+        loadTests();
+        start();
+    `),
+    ).toMatchInlineSnapshot(`
+      "
+              import Application from 'my-empty-classic-app/app';
+              import config from 'my-empty-classic-app/config/environment';
+              import * as QUnit from 'qunit';
+              import { setApplication } from '@ember/test-helpers';
+              import { setup } from 'qunit-dom';
+              import { start as qunitStart, setupEmberOnerrorValidation } from 'ember-qunit';
+
+              declare global {}
+
+              export function start() {
+                      setApplication(Application.create(config.APP));
+
+                      setup(QUnit.assert);
+                      setupEmberOnerrorValidation();
+                      qunitStart();
               }
           "
     `);

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:lib": "vitest lib/**/*.test.js"
   },
   "dependencies": {
+    "@babel/parser": "^7.29.2",
     "@ember/app-blueprint": "^6.10.0",
     "@embroider/shared-internals": "^3.0.1",
     "babel-remove-types": "^1.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@babel/parser':
+        specifier: ^7.29.2
+        version: 7.29.2
       '@ember/app-blueprint':
         specifier: ^6.10.0
         version: 6.10.3
@@ -181,8 +184,16 @@ packages:
     resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.25.9':
     resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.25.9':
@@ -193,8 +204,8 @@ packages:
     resolution: {integrity: sha512-Mz/4+y8udxBKdmzt/UjPACs4G3j5SshJJEFFKxlCGPydG4JAHXxjWjAwjd09tf6oINvl1VfMJo+nB7H2YKQ0dA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.26.9':
-    resolution: {integrity: sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==}
+  '@babel/parser@7.29.2':
+    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -240,6 +251,10 @@ packages:
 
   '@babel/types@7.26.9':
     resolution: {integrity: sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
   '@cnakazawa/watch@1.0.4':
@@ -4928,7 +4943,7 @@ snapshots:
       '@babel/helper-compilation-targets': 7.26.5
       '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.9)
       '@babel/helpers': 7.26.9
-      '@babel/parser': 7.26.9
+      '@babel/parser': 7.29.2
       '@babel/template': 7.26.9
       '@babel/traverse': 7.26.9
       '@babel/types': 7.26.9
@@ -4942,7 +4957,7 @@ snapshots:
 
   '@babel/generator@7.26.9':
     dependencies:
-      '@babel/parser': 7.26.9
+      '@babel/parser': 7.29.2
       '@babel/types': 7.26.9
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
@@ -5020,7 +5035,11 @@ snapshots:
 
   '@babel/helper-string-parser@7.25.9': {}
 
+  '@babel/helper-string-parser@7.27.1': {}
+
   '@babel/helper-validator-identifier@7.25.9': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/helper-validator-option@7.25.9': {}
 
@@ -5029,9 +5048,9 @@ snapshots:
       '@babel/template': 7.26.9
       '@babel/types': 7.26.9
 
-  '@babel/parser@7.26.9':
+  '@babel/parser@7.29.2':
     dependencies:
-      '@babel/types': 7.26.9
+      '@babel/types': 7.29.0
 
   '@babel/plugin-syntax-decorators@7.25.9(@babel/core@7.26.9)':
     dependencies:
@@ -5074,14 +5093,14 @@ snapshots:
   '@babel/template@7.26.9':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@babel/parser': 7.26.9
+      '@babel/parser': 7.29.2
       '@babel/types': 7.26.9
 
   '@babel/traverse@7.26.9':
     dependencies:
       '@babel/code-frame': 7.26.2
       '@babel/generator': 7.26.9
-      '@babel/parser': 7.26.9
+      '@babel/parser': 7.29.2
       '@babel/template': 7.26.9
       '@babel/types': 7.26.9
       debug: 4.4.0
@@ -5093,6 +5112,11 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
 
   '@cnakazawa/watch@1.0.4':
     dependencies:


### PR DESCRIPTION
We have code in the codemod that allows you to transform TS files and JS files depending on what your project is using, but if you encounter any TS specific syntax it would fail with a parse error.

This PR starts using a method described in https://github.com/benjamn/recast/pull/461 upstream in recast to support TS parsing and transformation 👍 