### PR TITLE
update node to 20.19+ in CI to fix require(esm)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: pnpm
@@ -29,9 +29,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: pnpm
@@ -88,15 +88,15 @@ jobs:
           - file: typescript
             version: ember-cli-4.12
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: pnpm
       - run: pnpm i --frozen-lockfile
       - name: Set TEMP to D:/Temp on windows
-        if: ${{matrix.os}} == windows-latest
+        if: ${{matrix.os == 'windows-latest'}}
         run: |
           mkdir "D:\\Temp"
           echo "TEMP=D:\\Temp" >> $env:GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: pnpm
       - run: pnpm i --frozen-lockfile
       - run: pnpm run lint
@@ -33,7 +33,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: pnpm
       - run: pnpm i --frozen-lockfile
       - run: pnpm test:lib
@@ -92,7 +92,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: pnpm
       - run: pnpm i --frozen-lockfile
       - name: Set TEMP to D:/Temp on windows

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-use-node-version=20.18.3

--- a/tests/fixtures/testem-proxy.js
+++ b/tests/fixtures/testem-proxy.js
@@ -20,7 +20,7 @@ module.exports.testemProxy = function testemProxy(targetURL, base = '/') {
       res && res.status && res.status(500).json(err);
     });
 
-    app.all('*', (req, res, next) => {
+    app.all('*name', (req, res, next) => {
       let url = req.url;
       if (url === `${base}testem.js` || url.startsWith('/testem/')) {
         req.url = req.url.replace(base, '/');


### PR DESCRIPTION
~I'm not exactly sure if this is breaking 🤔 did we ever support node 18? I guess so and maybe we should just drop support now~

Edit: I know this isn't breaking because even though we had Node 18 in CI we were actually running with node 20.18 because of a `.npmrc` file. I have removed this file and now we're running against the version of node on CI 👍 