### PR TITLE
update @ember/app-blueprint

### DIFF
--- a/lib/tasks/update-package-json.test.js
+++ b/lib/tasks/update-package-json.test.js
@@ -99,21 +99,21 @@ describe('updatePackageJson() function', () => {
     await updatePackageJson();
     expect(files['package.json']['devDependencies']).toMatchInlineSnapshot(`
       {
-        "@babel/plugin-transform-runtime": "^7.28.5",
+        "@babel/plugin-transform-runtime": "^7.29.0",
         "@ember/string": "^4.0.1",
         "@ember/test-helpers": "^5.4.1",
-        "@embroider/compat": "^4.1.12",
+        "@embroider/compat": "^4.1.17",
         "@embroider/config-meta-loader": "^1.0.0",
-        "@embroider/core": "^4.4.2",
+        "@embroider/core": "^4.4.7",
         "@embroider/legacy-inspector-support": "^0.1.3",
-        "@embroider/vite": "^1.5.0",
-        "@rollup/plugin-babel": "^6.1.0",
+        "@embroider/vite": "^1.7.2",
+        "@rollup/plugin-babel": "^7.0.0",
         "babel-plugin-ember-template-compilation": "^3.1.0",
         "decorator-transforms": "^2.3.1",
         "ember-load-initializers": "^3.0.1",
         "ember-qunit": "^9.0.4",
-        "ember-resolver": "^13.1.1",
-        "vite": "^7.3.1",
+        "ember-resolver": "^13.2.0",
+        "vite": "^8.0.10",
       }
     `);
   });
@@ -128,22 +128,22 @@ describe('updatePackageJson() function', () => {
     await updatePackageJson({ ts: true });
     expect(files['package.json']['devDependencies']).toMatchInlineSnapshot(`
       {
-        "@babel/plugin-transform-runtime": "^7.28.5",
+        "@babel/plugin-transform-runtime": "^7.29.0",
         "@babel/plugin-transform-typescript": "^7.28.6",
         "@ember/string": "^4.0.1",
         "@ember/test-helpers": "^5.4.1",
-        "@embroider/compat": "^4.1.12",
+        "@embroider/compat": "^4.1.17",
         "@embroider/config-meta-loader": "^1.0.0",
-        "@embroider/core": "^4.4.2",
+        "@embroider/core": "^4.4.7",
         "@embroider/legacy-inspector-support": "^0.1.3",
-        "@embroider/vite": "^1.5.0",
-        "@rollup/plugin-babel": "^6.1.0",
+        "@embroider/vite": "^1.7.2",
+        "@rollup/plugin-babel": "^7.0.0",
         "babel-plugin-ember-template-compilation": "^3.1.0",
         "decorator-transforms": "^2.3.1",
         "ember-load-initializers": "^3.0.1",
         "ember-qunit": "^9.0.4",
-        "ember-resolver": "^13.1.1",
-        "vite": "^7.3.1",
+        "ember-resolver": "^13.2.0",
+        "vite": "^8.0.10",
       }
     `);
   });
@@ -192,19 +192,19 @@ describe('updatePackageJson() function', () => {
     `);
     expect(files['package.json']['devDependencies']).toMatchInlineSnapshot(`
       {
-        "@babel/plugin-transform-runtime": "^7.28.5",
+        "@babel/plugin-transform-runtime": "^7.29.0",
         "@ember/test-helpers": "^5.4.1",
-        "@embroider/compat": "^4.1.12",
+        "@embroider/compat": "^4.1.17",
         "@embroider/config-meta-loader": "^1.0.0",
         "@embroider/core": "100.0.0",
         "@embroider/legacy-inspector-support": "^0.1.3",
-        "@embroider/vite": "^1.5.0",
-        "@rollup/plugin-babel": "^6.1.0",
+        "@embroider/vite": "^1.7.2",
+        "@rollup/plugin-babel": "^7.0.0",
         "babel-plugin-ember-template-compilation": "^3.1.0",
         "decorator-transforms": "^2.3.1",
         "ember-load-initializers": "^3.0.1",
         "ember-qunit": "^9.0.4",
-        "ember-resolver": "^13.1.1",
+        "ember-resolver": "^13.2.0",
       }
     `);
   });

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@babel/parser": "^7.29.2",
-    "@ember/app-blueprint": "^6.10.0",
+    "@ember/app-blueprint": "^6.12.3",
     "@embroider/shared-internals": "^3.0.1",
     "babel-remove-types": "^1.0.1",
     "commander": "^13.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^7.29.2
         version: 7.29.2
       '@ember/app-blueprint':
-        specifier: ^6.10.0
-        version: 6.10.3
+        specifier: ^6.12.3
+        version: 6.12.3
       '@embroider/shared-internals':
         specifier: ^3.0.1
         version: 3.0.1
@@ -262,8 +262,8 @@ packages:
     engines: {node: '>=0.1.95'}
     hasBin: true
 
-  '@ember/app-blueprint@6.10.3':
-    resolution: {integrity: sha512-W/JJI9u2aDmX1Eef9WlpovY2luJoP8AHG5GqKWHsqtPCxKa3PhlzVRQDY3nRuuBYqA2fQFQYksffyalhWHCuDw==}
+  '@ember/app-blueprint@6.12.3':
+    resolution: {integrity: sha512-Bf950zkgbKn6/pMunLTk/mkqInHU8CaNTvjR/umX1CjUNFRPTZPQb19OhstlBYTl+99jUN3feZ0xfuOt1t6c7A==}
 
   '@embroider/shared-internals@3.0.1':
     resolution: {integrity: sha512-d7RQwDwqqHo7YvjE9t1rtIrCCYtbSoO0uRq2ikVhRh4hGS5OojZNu2ZtS0Wqrg+V72CRtMFr/hibTvHNsRM2Lg==}
@@ -5123,7 +5123,7 @@ snapshots:
       exec-sh: 0.3.6
       minimist: 1.2.8
 
-  '@ember/app-blueprint@6.10.3':
+  '@ember/app-blueprint@6.12.3':
     dependencies:
       chalk: 4.1.2
       ejs: 3.1.10
@@ -6286,7 +6286,7 @@ snapshots:
 
   builtins@5.1.0:
     dependencies:
-      semver: 7.7.1
+      semver: 7.7.4
 
   bytes@1.0.0: {}
 


### PR DESCRIPTION
This means that people using the ember-vite-codemod will start to get Vite 8 🎉 