### PR TITLE
Update transforms to pass availableModules in index-html for ember-exam when present & add CLI option

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { program, Option } from 'commander';
+import { program, Option, InvalidArgumentError } from 'commander';
 import { readFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -15,6 +15,7 @@ import { checkModulePrefixMisMatch } from './lib/tasks/check-modulePrefix-mismat
 import { detectTypescript } from './lib/utils/detect-typescript.js';
 import { isExit } from './lib/utils/exit.js';
 import { run } from './lib/utils/run.js';
+import { detectEmberExam } from './lib/utils/detect-ember-exam.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(await readFile(join(__dirname, 'package.json'), 'utf8'));
@@ -48,11 +49,25 @@ program
       'indicate the app to migrate uses JavaScript (default: true when no TypeScript files are detected)',
     ).conflicts('ts'),
   )
+  .addOption(
+    new Option(
+      '--ember-exam [boolean]',
+      'indicate the app to migrate uses ember-exam (default: true when ember-exam dependency is detected)',
+    ).argParser((value) => {
+      if (value === 'true') return true;
+      if (value === 'false') return false;
+      throw new InvalidArgumentError('Expected "true" or "false".');
+    }),
+  )
   .option('--error-trace', 'print the whole error trace when available', false)
   .version(pkg.version)
   .action(async (options) => {
     options.ts ??= !options.js && detectTypescript();
     delete options.js;
+
+    if (options.emberExam === undefined) {
+      options.emberExam = await detectEmberExam();
+    }
 
     if (options.embroiderWebpack) {
       console.warn(

--- a/lib/tasks/transform-files.js
+++ b/lib/tasks/transform-files.js
@@ -25,16 +25,12 @@ export default async function modifyFiles(options) {
     emberVersion = coerce(emberVersion).version;
   }
 
-  const hasEmberExam =
-    packageJSON['devDependencies']['ember-exam'] ??
-    packageJSON['dependencies']['ember-exam'];
-
   await transformWithReplace('index.html', transformIndexHTML, {
     isTest: false,
   });
   await transformWithReplace('tests/index.html', transformIndexHTML, {
     isTest: true,
-    hasEmberExam,
+    emberExam: options.emberExam,
   });
 
   if (options.ts) {

--- a/lib/tasks/transform-files.js
+++ b/lib/tasks/transform-files.js
@@ -91,11 +91,15 @@ async function transformWithReplace(file, transformFunction, options) {
 async function transformWithAst(
   file,
   transformFunction,
-  { embroiderWebpack, errorTrace, emberVersion },
+  { embroiderWebpack, errorTrace, emberVersion, emberExam },
 ) {
   try {
     let ast = await getAst(file);
-    ast = await transformFunction(ast, { embroiderWebpack, emberVersion });
+    ast = await transformFunction(ast, {
+      embroiderWebpack,
+      emberVersion,
+      emberExam,
+    });
     await setCode(file, ast);
   } catch (e) {
     console.error(

--- a/lib/tasks/transform-files.js
+++ b/lib/tasks/transform-files.js
@@ -91,16 +91,15 @@ async function transformWithReplace(file, transformFunction, options) {
 async function transformWithAst(
   file,
   transformFunction,
-  { embroiderWebpack, errorTrace, emberVersion, emberExam },
+  { embroiderWebpack, errorTrace, emberVersion, emberExam, ts },
 ) {
   try {
     let ast = await getAst(file);
-    let extension = file.split('.').pop();
     ast = await transformFunction(ast, {
       embroiderWebpack,
       emberVersion,
       emberExam,
-      extension,
+      ts,
     });
     await setCode(file, ast);
   } catch (e) {

--- a/lib/tasks/transform-files.js
+++ b/lib/tasks/transform-files.js
@@ -25,11 +25,16 @@ export default async function modifyFiles(options) {
     emberVersion = coerce(emberVersion).version;
   }
 
+  const hasEmberExam =
+    packageJSON['devDependencies']['ember-exam'] ??
+    packageJSON['dependencies']['ember-exam'];
+
   await transformWithReplace('index.html', transformIndexHTML, {
     isTest: false,
   });
   await transformWithReplace('tests/index.html', transformIndexHTML, {
     isTest: true,
+    hasEmberExam,
   });
 
   if (options.ts) {

--- a/lib/tasks/transform-files.js
+++ b/lib/tasks/transform-files.js
@@ -95,10 +95,12 @@ async function transformWithAst(
 ) {
   try {
     let ast = await getAst(file);
+    let extension = file.split('.').pop();
     ast = await transformFunction(ast, {
       embroiderWebpack,
       emberVersion,
       emberExam,
+      extension,
     });
     await setCode(file, ast);
   } catch (e) {

--- a/lib/transforms/index-html.js
+++ b/lib/transforms/index-html.js
@@ -1,9 +1,6 @@
 import { getAppName } from '../utils/get-app-name.js';
 
-export default async function transformIndexHTML(
-  code,
-  { isTest, hasEmberExam },
-) {
+export default async function transformIndexHTML(code, { isTest, emberExam }) {
   const sharedReplacements = [
     {
       before: '{{rootURL}}assets/vendor.css',
@@ -50,7 +47,7 @@ export default async function transformIndexHTML(
     <script type="module">
       import { start } from './test-helper';
       ${
-        hasEmberExam
+        emberExam
           ? `const availableModules = import.meta.glob("./**/*.{js,ts,gjs,gts}");
       start({ availableModules });`
           : `import.meta.glob("./**/*.{js,ts,gjs,gts}", { eager: true });

--- a/lib/transforms/index-html.js
+++ b/lib/transforms/index-html.js
@@ -1,6 +1,9 @@
 import { getAppName } from '../utils/get-app-name.js';
 
-export default async function transformIndexHTML(code, { isTest }) {
+export default async function transformIndexHTML(
+  code,
+  { isTest, hasEmberExam },
+) {
   const sharedReplacements = [
     {
       before: '{{rootURL}}assets/vendor.css',
@@ -46,8 +49,13 @@ export default async function transformIndexHTML(code, { isTest }) {
       after: `<script type="module">import "ember-testing";</script>
     <script type="module">
       import { start } from './test-helper';
-      import.meta.glob("./**/*.{js,ts,gjs,gts}", { eager: true });
-      start();
+      ${
+        hasEmberExam
+          ? `const availableModules = import.meta.glob("./**/*.{js,ts,gjs,gts}");
+      start({ availableModules });`
+          : `import.meta.glob("./**/*.{js,ts,gjs,gts}", { eager: true });
+      start();`
+      }
     </script>`,
     },
     {

--- a/lib/transforms/index-html.test.js
+++ b/lib/transforms/index-html.test.js
@@ -1,0 +1,274 @@
+import { describe, it, expect, vi } from 'vitest';
+import transformIndexHTML from './index-html.js';
+
+vi.mock('../utils/get-app-name', async () => {
+  return {
+    getAppName: () => 'fancy-app',
+  };
+});
+
+async function parseAndApply(
+  code,
+  options = { isTest: false, hasEmberExam: false },
+) {
+  return await transformIndexHTML(code, options);
+}
+
+describe('index.html', () => {
+  it('transforms a default index.html', async () => {
+    expect(
+      await parseAndApply(`
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>MyApp</title>
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    {{content-for "head"}}
+
+    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/fancy-app.css">
+
+    {{content-for "head-footer"}}
+  </head>
+  <body>
+    {{content-for "body"}}
+
+    <script src="{{rootURL}}assets/vendor.js"></script>
+    <script src="{{rootURL}}assets/fancy-app.js"></script>
+
+    {{content-for "body-footer"}}
+  </body>
+</html>
+    `),
+    ).toMatchInlineSnapshot(`
+      "
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <meta charset="utf-8">
+          <title>MyApp</title>
+          <meta name="description" content="">
+          <meta name="viewport" content="width=device-width, initial-scale=1">
+
+          {{content-for "head"}}
+
+          <link integrity="" rel="stylesheet" href="/@embroider/virtual/vendor.css">
+          <link integrity="" rel="stylesheet" href="/@embroider/virtual/app.css">
+
+          {{content-for "head-footer"}}
+        </head>
+        <body>
+          {{content-for "body"}}
+
+          <script src="/@embroider/virtual/vendor.js"></script>
+          <script type="module">
+            import Application from './app/app';
+            import environment from './app/config/environment';
+
+            Application.create(environment.APP);
+          </script>
+
+          {{content-for "body-footer"}}
+        </body>
+      </html>
+          "
+    `);
+  });
+});
+
+describe('tests/index.html', () => {
+  it('transforms a default tests/index.html', async () => {
+    expect(
+      await parseAndApply(
+        `
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>MyApp Tests</title>
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    {{content-for "head"}}
+    {{content-for "test-head"}}
+
+    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/fancy-app.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/test-support.css">
+
+    {{content-for "head-footer"}}
+    {{content-for "test-head-footer"}}
+  </head>
+  <body>
+    {{content-for "body"}}
+    {{content-for "test-body"}}
+
+    <div id="qunit"></div>
+    <div id="qunit-fixture">
+      <div id="ember-testing-container">
+        <div id="ember-testing"></div>
+      </div>
+    </div>
+
+    <script src="/testem.js" integrity="" data-embroider-ignore></script>
+    <script src="{{rootURL}}assets/vendor.js"></script>
+    <script src="{{rootURL}}assets/test-support.js"></script>
+    <script src="{{rootURL}}assets/fancy-app.js"></script>
+    <script src="{{rootURL}}assets/tests.js"></script>
+
+    {{content-for "body-footer"}}
+    {{content-for "test-body-footer"}}
+  </body>
+</html>
+    `,
+        { isTest: true },
+      ),
+    ).toMatchInlineSnapshot(`
+      "
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <meta charset="utf-8">
+          <title>MyApp Tests</title>
+          <meta name="description" content="">
+          <meta name="viewport" content="width=device-width, initial-scale=1">
+
+          {{content-for "head"}}
+          {{content-for "test-head"}}
+
+          <link rel="stylesheet" href="/@embroider/virtual/vendor.css">
+          <link rel="stylesheet" href="/@embroider/virtual/app.css">
+          <link rel="stylesheet" href="/@embroider/virtual/test-support.css">
+
+          {{content-for "head-footer"}}
+          {{content-for "test-head-footer"}}
+        </head>
+        <body>
+          {{content-for "body"}}
+          {{content-for "test-body"}}
+
+          <div id="qunit"></div>
+          <div id="qunit-fixture">
+            <div id="ember-testing-container">
+              <div id="ember-testing"></div>
+            </div>
+          </div>
+
+          <script src="/testem.js" integrity="" data-embroider-ignore></script>
+          <script src="/@embroider/virtual/vendor.js"></script>
+          <script src="/@embroider/virtual/test-support.js"></script>
+          
+          <script type="module">import "ember-testing";</script>
+          <script type="module">
+            import { start } from './test-helper';
+            import.meta.glob("./**/*.{js,ts,gjs,gts}", { eager: true });
+            start();
+          </script>
+
+          {{content-for "body-footer"}}
+          
+        </body>
+      </html>
+          "
+    `);
+  });
+
+  it('transforms a tests/index.html with ember-exam support', async () => {
+    expect(
+      await parseAndApply(
+        `
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>MyApp Tests</title>
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    {{content-for "head"}}
+    {{content-for "test-head"}}
+
+    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/fancy-app.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/test-support.css">
+
+    {{content-for "head-footer"}}
+    {{content-for "test-head-footer"}}
+  </head>
+  <body>
+    {{content-for "body"}}
+    {{content-for "test-body"}}
+
+    <div id="qunit"></div>
+    <div id="qunit-fixture">
+      <div id="ember-testing-container">
+        <div id="ember-testing"></div>
+      </div>
+    </div>
+
+    <script src="/testem.js" integrity="" data-embroider-ignore></script>
+    <script src="{{rootURL}}assets/vendor.js"></script>
+    <script src="{{rootURL}}assets/test-support.js"></script>
+    <script src="{{rootURL}}assets/fancy-app.js"></script>
+    <script src="{{rootURL}}assets/tests.js"></script>
+
+    {{content-for "body-footer"}}
+    {{content-for "test-body-footer"}}
+  </body>
+</html>
+    `,
+        { isTest: true, hasEmberExam: true },
+      ),
+    ).toMatchInlineSnapshot(`
+      "
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <meta charset="utf-8">
+          <title>MyApp Tests</title>
+          <meta name="description" content="">
+          <meta name="viewport" content="width=device-width, initial-scale=1">
+
+          {{content-for "head"}}
+          {{content-for "test-head"}}
+
+          <link rel="stylesheet" href="/@embroider/virtual/vendor.css">
+          <link rel="stylesheet" href="/@embroider/virtual/app.css">
+          <link rel="stylesheet" href="/@embroider/virtual/test-support.css">
+
+          {{content-for "head-footer"}}
+          {{content-for "test-head-footer"}}
+        </head>
+        <body>
+          {{content-for "body"}}
+          {{content-for "test-body"}}
+
+          <div id="qunit"></div>
+          <div id="qunit-fixture">
+            <div id="ember-testing-container">
+              <div id="ember-testing"></div>
+            </div>
+          </div>
+
+          <script src="/testem.js" integrity="" data-embroider-ignore></script>
+          <script src="/@embroider/virtual/vendor.js"></script>
+          <script src="/@embroider/virtual/test-support.js"></script>
+          
+          <script type="module">import "ember-testing";</script>
+          <script type="module">
+            import { start } from './test-helper';
+            const availableModules = import.meta.glob("./**/*.{js,ts,gjs,gts}");
+            start({ availableModules });
+          </script>
+
+          {{content-for "body-footer"}}
+          
+        </body>
+      </html>
+          "
+    `);
+  });
+});

--- a/lib/transforms/index-html.test.js
+++ b/lib/transforms/index-html.test.js
@@ -9,7 +9,7 @@ vi.mock('../utils/get-app-name', async () => {
 
 async function parseAndApply(
   code,
-  options = { isTest: false, hasEmberExam: false },
+  options = { isTest: false, emberExam: false },
 ) {
   return await transformIndexHTML(code, options);
 }
@@ -220,7 +220,7 @@ describe('tests/index.html', () => {
   </body>
 </html>
     `,
-        { isTest: true, hasEmberExam: true },
+        { isTest: true, emberExam: true },
       ),
     ).toMatchInlineSnapshot(`
       "

--- a/lib/transforms/test-helper.js
+++ b/lib/transforms/test-helper.js
@@ -5,7 +5,7 @@ const b = types.builders;
 const topLevelModuleTypes = ['ImportDeclaration', 'TSModuleDeclaration'];
 
 export default async function transformTestHelper(ast, options) {
-  const isTypescript = options.extension === 'ts';
+  const isTypescript = options.ts;
 
   let exportStart = ast.program.body.find((node) => {
     return (

--- a/lib/transforms/test-helper.js
+++ b/lib/transforms/test-helper.js
@@ -4,7 +4,7 @@ const b = types.builders;
 
 const topLevelModuleTypes = ['ImportDeclaration', 'TSModuleDeclaration'];
 
-export default async function transformTestHelper(ast) {
+export default async function transformTestHelper(ast, options) {
   let exportStart = ast.program.body.find((node) => {
     return (
       node.type === 'ExportNamedDeclaration' &&
@@ -70,7 +70,9 @@ export default async function transformTestHelper(ast) {
       node.source.value === 'ember-exam/test-support/start',
   );
   const examImport = emberExamImport || emberExamStartImport;
-  if (examImport) {
+  const hasEmberExam = options.emberExam !== false && examImport;
+
+  if (hasEmberExam) {
     examImport.source.value = 'ember-exam/addon-test-support';
 
     const startSpecifierIndex = examImport.specifiers.findIndex((specifier) => {
@@ -104,14 +106,15 @@ export default async function transformTestHelper(ast) {
   });
 
   let hasEmberOnerrorValidationCall = false;
-  const hasEmberExam = Boolean(emberExamImport || emberExamStartImport);
+  const hasEmberExamImport =
+    hasEmberExam && Boolean(emberExamImport || emberExamStartImport);
 
   visit(ast, {
     // We need this extra visitor since we need to add an AwaitExpression which
     // can't be done from visitCallExpression.
     visitExpressionStatement(path) {
       if (
-        hasEmberExam &&
+        hasEmberExamImport &&
         path.value.expression.type === 'CallExpression' &&
         path.value.expression.callee &&
         path.value.expression.callee.type === 'Identifier' &&
@@ -193,7 +196,7 @@ export default async function transformTestHelper(ast) {
       b.blockStatement(nodesToWrap),
     ),
   );
-  if (hasEmberExam) {
+  if (hasEmberExamImport) {
     exportStart.declaration.async = true;
   }
   ast.program.body = [...filteredModuleLevelStatements, exportStart];

--- a/lib/transforms/test-helper.js
+++ b/lib/transforms/test-helper.js
@@ -5,6 +5,8 @@ const b = types.builders;
 const topLevelModuleTypes = ['ImportDeclaration', 'TSModuleDeclaration'];
 
 export default async function transformTestHelper(ast, options) {
+  const isTypescript = options.extension === 'ts';
+
   let exportStart = ast.program.body.find((node) => {
     return (
       node.type === 'ExportNamedDeclaration' &&
@@ -90,6 +92,13 @@ export default async function transformTestHelper(ast, options) {
         b.identifier('startEmberExam'),
       );
     }
+    if (isTypescript) {
+      const emberExamTypeImport = b.importSpecifier(
+        b.identifier('EmberExamStartOptions'),
+      );
+      emberExamTypeImport.importKind = 'type';
+      examImport.specifiers.push(emberExamTypeImport);
+    }
   }
 
   // Move all import declarations at the top
@@ -122,7 +131,7 @@ export default async function transformTestHelper(ast, options) {
       ) {
         path.value.expression = b.awaitExpression(
           b.callExpression(b.identifier('startEmberExam'), [
-            b.identifier('...restParams'),
+            b.identifier('options'),
           ]),
         );
         return false;
@@ -191,7 +200,16 @@ export default async function transformTestHelper(ast, options) {
     nodesToWrap.splice(qunitStartIndex, 0, expression);
   }
 
-  const params = hasEmberExamImport ? [b.identifier('...restParams')] : [];
+  let params = [];
+  if (hasEmberExamImport) {
+    const options = b.identifier('options');
+    if (isTypescript) {
+      options.typeAnnotation = b.tsTypeAnnotation(
+        b.tsTypeReference(b.identifier('EmberExamStartOptions')),
+      );
+    }
+    params.push(options);
+  }
   exportStart = b.exportNamedDeclaration(
     b.functionDeclaration(
       b.identifier('start'),

--- a/lib/transforms/test-helper.js
+++ b/lib/transforms/test-helper.js
@@ -121,7 +121,9 @@ export default async function transformTestHelper(ast, options) {
         path.value.expression.callee.name === 'start'
       ) {
         path.value.expression = b.awaitExpression(
-          b.callExpression(b.identifier('startEmberExam'), []),
+          b.callExpression(b.identifier('startEmberExam'), [
+            b.identifier('...restParams'),
+          ]),
         );
         return false;
       }
@@ -189,10 +191,11 @@ export default async function transformTestHelper(ast, options) {
     nodesToWrap.splice(qunitStartIndex, 0, expression);
   }
 
+  const params = hasEmberExamImport ? [b.identifier('...restParams')] : [];
   exportStart = b.exportNamedDeclaration(
     b.functionDeclaration(
       b.identifier('start'),
-      [],
+      params,
       b.blockStatement(nodesToWrap),
     ),
   );

--- a/lib/transforms/test-helper.test.js
+++ b/lib/transforms/test-helper.test.js
@@ -3,9 +3,9 @@ import { print } from 'recast';
 import transformTestHelper from './test-helper.js';
 import { parseAst } from '../tasks/transform-files.js';
 
-async function parseAndApply(input) {
+async function parseAndApply(input, options = {}) {
   let ast = parseAst(input);
-  ast = await transformTestHelper(ast);
+  ast = await transformTestHelper(ast, options);
   return print(ast).code;
 }
 
@@ -143,6 +143,88 @@ describe('test-helper() function', () => {
         setupEmberOnerrorValidation();
         start();
     `),
+    ).toMatchInlineSnapshot(`
+      "
+              import Application from 'my-empty-classic-app/app';
+              import config from 'my-empty-classic-app/config/environment';
+              import * as QUnit from 'qunit';
+              import { setApplication } from '@ember/test-helpers';
+              import { setup } from 'qunit-dom';
+              import { setupEmberOnerrorValidation } from 'ember-qunit';
+              import { start as startEmberExam } from "ember-exam/addon-test-support";
+
+              export async function start() {
+                      setApplication(Application.create(config.APP));
+
+                      setup(QUnit.assert);
+                      setupEmberOnerrorValidation();
+                      await startEmberExam();
+              }
+          "
+    `);
+  });
+
+  it('does not touch ember-exam when forced off', async () => {
+    expect(
+      await parseAndApply(
+        `
+        import Application from 'my-empty-classic-app/app';
+        import config from 'my-empty-classic-app/config/environment';
+        import * as QUnit from 'qunit';
+        import { setApplication } from '@ember/test-helpers';
+        import { setup } from 'qunit-dom';
+        import { setupEmberOnerrorValidation } from 'ember-qunit';
+        import { start } from 'ember-exam/test-support';
+
+        setApplication(Application.create(config.APP));
+
+        setup(QUnit.assert);
+        setupEmberOnerrorValidation();
+        start();
+    `,
+        { emberExam: false },
+      ),
+    ).toMatchInlineSnapshot(`
+      "
+              import Application from 'my-empty-classic-app/app';
+              import config from 'my-empty-classic-app/config/environment';
+              import * as QUnit from 'qunit';
+              import { setApplication } from '@ember/test-helpers';
+              import { setup } from 'qunit-dom';
+              import { setupEmberOnerrorValidation } from 'ember-qunit';
+              import { start } from 'ember-exam/test-support';
+
+              export function start() {
+                      setApplication(Application.create(config.APP));
+
+                      setup(QUnit.assert);
+                      setupEmberOnerrorValidation();
+                      qunitStart();
+              }
+          "
+    `);
+  });
+
+  it('handles ember-exam when forced on', async () => {
+    expect(
+      await parseAndApply(
+        `
+        import Application from 'my-empty-classic-app/app';
+        import config from 'my-empty-classic-app/config/environment';
+        import * as QUnit from 'qunit';
+        import { setApplication } from '@ember/test-helpers';
+        import { setup } from 'qunit-dom';
+        import { setupEmberOnerrorValidation } from 'ember-qunit';
+        import { start } from 'ember-exam/test-support';
+
+        setApplication(Application.create(config.APP));
+
+        setup(QUnit.assert);
+        setupEmberOnerrorValidation();
+        start();
+    `,
+        { emberExam: true },
+      ),
     ).toMatchInlineSnapshot(`
       "
               import Application from 'my-empty-classic-app/app';

--- a/lib/transforms/test-helper.test.js
+++ b/lib/transforms/test-helper.test.js
@@ -153,12 +153,12 @@ describe('test-helper() function', () => {
               import { setupEmberOnerrorValidation } from 'ember-qunit';
               import { start as startEmberExam } from "ember-exam/addon-test-support";
 
-              export async function start(...restParams) {
+              export async function start(options) {
                       setApplication(Application.create(config.APP));
 
                       setup(QUnit.assert);
                       setupEmberOnerrorValidation();
-                      await startEmberExam(...restParams);
+                      await startEmberExam(options);
               }
           "
     `);
@@ -235,12 +235,12 @@ describe('test-helper() function', () => {
               import { setupEmberOnerrorValidation } from 'ember-qunit';
               import { start as startEmberExam } from "ember-exam/addon-test-support";
 
-              export async function start(...restParams) {
+              export async function start(options) {
                       setApplication(Application.create(config.APP));
 
                       setup(QUnit.assert);
                       setupEmberOnerrorValidation();
-                      await startEmberExam(...restParams);
+                      await startEmberExam(options);
               }
           "
     `);
@@ -273,12 +273,12 @@ describe('test-helper() function', () => {
               import { setupEmberOnerrorValidation } from 'ember-qunit';
               import { start as startEmberExam } from "ember-exam/addon-test-support";
 
-              export async function start(...restParams) {
+              export async function start(options) {
                       setApplication(Application.create(config.APP));
 
                       setup(QUnit.assert);
                       setupEmberOnerrorValidation();
-                      await startEmberExam(...restParams);
+                      await startEmberExam(options);
               }
           "
     `);
@@ -321,6 +321,47 @@ describe('test-helper() function', () => {
                       setup(QUnit.assert);
                       setupEmberOnerrorValidation();
                       qunitStart();
+              }
+          "
+    `);
+  });
+
+  it('works with ember-exam in a TS file', async () => {
+    expect(
+      await parseAndApply(
+        `
+        import Application from 'my-empty-classic-app/app';
+        import config from 'my-empty-classic-app/config/environment';
+        import * as QUnit from 'qunit';
+        import { setApplication } from '@ember/test-helpers';
+        import { setup } from 'qunit-dom';
+        import { setupEmberOnerrorValidation } from 'ember-qunit';
+        import { start } from 'ember-exam/test-support';
+
+        setApplication(Application.create(config.APP));
+
+        setup(QUnit.assert);
+        setupEmberOnerrorValidation();
+        start();
+    `,
+        { extension: 'ts' },
+      ),
+    ).toMatchInlineSnapshot(`
+      "
+              import Application from 'my-empty-classic-app/app';
+              import config from 'my-empty-classic-app/config/environment';
+              import * as QUnit from 'qunit';
+              import { setApplication } from '@ember/test-helpers';
+              import { setup } from 'qunit-dom';
+              import { setupEmberOnerrorValidation } from 'ember-qunit';
+              import { start as startEmberExam, type EmberExamStartOptions } from "ember-exam/addon-test-support";
+
+              export async function start(options: EmberExamStartOptions) {
+                      setApplication(Application.create(config.APP));
+
+                      setup(QUnit.assert);
+                      setupEmberOnerrorValidation();
+                      await startEmberExam(options);
               }
           "
     `);

--- a/lib/transforms/test-helper.test.js
+++ b/lib/transforms/test-helper.test.js
@@ -344,7 +344,7 @@ describe('test-helper() function', () => {
         setupEmberOnerrorValidation();
         start();
     `,
-        { extension: 'ts' },
+        { ts: true },
       ),
     ).toMatchInlineSnapshot(`
       "

--- a/lib/transforms/test-helper.test.js
+++ b/lib/transforms/test-helper.test.js
@@ -153,12 +153,12 @@ describe('test-helper() function', () => {
               import { setupEmberOnerrorValidation } from 'ember-qunit';
               import { start as startEmberExam } from "ember-exam/addon-test-support";
 
-              export async function start() {
+              export async function start(...restParams) {
                       setApplication(Application.create(config.APP));
 
                       setup(QUnit.assert);
                       setupEmberOnerrorValidation();
-                      await startEmberExam();
+                      await startEmberExam(...restParams);
               }
           "
     `);
@@ -235,12 +235,12 @@ describe('test-helper() function', () => {
               import { setupEmberOnerrorValidation } from 'ember-qunit';
               import { start as startEmberExam } from "ember-exam/addon-test-support";
 
-              export async function start() {
+              export async function start(...restParams) {
                       setApplication(Application.create(config.APP));
 
                       setup(QUnit.assert);
                       setupEmberOnerrorValidation();
-                      await startEmberExam();
+                      await startEmberExam(...restParams);
               }
           "
     `);
@@ -273,12 +273,12 @@ describe('test-helper() function', () => {
               import { setupEmberOnerrorValidation } from 'ember-qunit';
               import { start as startEmberExam } from "ember-exam/addon-test-support";
 
-              export async function start() {
+              export async function start(...restParams) {
                       setApplication(Application.create(config.APP));
 
                       setup(QUnit.assert);
                       setupEmberOnerrorValidation();
-                      await startEmberExam();
+                      await startEmberExam(...restParams);
               }
           "
     `);

--- a/lib/utils/detect-ember-exam.js
+++ b/lib/utils/detect-ember-exam.js
@@ -1,0 +1,10 @@
+import { readFile } from 'node:fs/promises';
+
+export async function detectEmberExam() {
+  const packageJSON = JSON.parse(await readFile('package.json', 'utf-8'));
+
+  return Boolean(
+    packageJSON.dependencies?.['ember-exam'] ||
+      packageJSON.devDependencies?.['ember-exam'],
+  );
+}


### PR DESCRIPTION
This is a followup for #153 to properly transform `tests/index.html` in case ember-exam is present. In the case of ember-exam we do _not_ want to eagerly `import.meta.glob` the test files and we need to explicitly pass the output of it to ember-exam as `availableModules`.

Additionally this adds a `--ember-exam [boolean]` option to the CLI. This is an optional parameter which can be used to forcefully enable or disable the ember-exam transforms. The presence of ember-exam is detected automatically if this option is not passed through the presence of the `ember-exam` (dev)dependency.

Since we didn't have (unit) tests yet for the index.html transform I've added tests for the basic 3 cases `index.html` and `tests/index.html` with and without ember-exam present and updated some tests affected by the new option.